### PR TITLE
feat: 와이어프레임 UI 구현

### DIFF
--- a/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/component/AdegoDatePicker.kt
+++ b/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/component/AdegoDatePicker.kt
@@ -1,0 +1,319 @@
+package com.teammanduk.adego.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+
+@Composable
+fun AdegoDatePicker(
+    show: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (Long?) -> Unit,
+    initialDate: Long? = null
+) {
+    if (!show) return
+
+    val today = remember {
+        Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }.timeInMillis
+    }
+
+    val calendar = remember { Calendar.getInstance() }
+    val defaultDate = initialDate ?: today
+    calendar.timeInMillis = defaultDate
+
+    var currentYear by remember { mutableStateOf(calendar.get(Calendar.YEAR)) }
+    var currentMonth by remember { mutableStateOf(calendar.get(Calendar.MONTH)) }
+    var selectedDateMillis by remember { mutableStateOf(defaultDate) }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .background(Color.White, RoundedCornerShape(16.dp))
+                .padding(24.dp)
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "날짜 선택",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = AdegoTheme.colors.onBackground,
+                    modifier = Modifier.weight(1f)
+                )
+
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "닫기",
+                        tint = AdegoTheme.colors.onBackground
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Month/Year Navigation
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(onClick = {
+                    val today = Calendar.getInstance()
+                    currentYear = today.get(Calendar.YEAR)
+                    currentMonth = today.get(Calendar.MONTH)
+                }) {
+                    Text(
+                        text = "오늘",
+                        style = AdegoTheme.typography.bodyLarge,
+                        color = AdegoTheme.colors.onBackground
+                    )
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    IconButton(
+                        onClick = {
+                            if (currentMonth == 0) {
+                                currentMonth = 11
+                                currentYear--
+                            } else {
+                                currentMonth--
+                            }
+                        },
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                            contentDescription = "이전 달",
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+
+                    Text(
+                        text = SimpleDateFormat("yyyy년 MM월", Locale.KOREAN).format(
+                            Calendar.getInstance().apply {
+                                set(Calendar.YEAR, currentYear)
+                                set(Calendar.MONTH, currentMonth)
+                            }.time
+                        ),
+                        style = AdegoTheme.typography.titleLarge
+                    )
+
+                    IconButton(
+                        onClick = {
+                            if (currentMonth == 11) {
+                                currentMonth = 0
+                                currentYear++
+                            } else {
+                                currentMonth++
+                            }
+                        },
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = "다음 달",
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Weekday Headers
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                listOf("일", "월", "화", "수", "목", "금", "토").forEach { day ->
+                    Text(
+                        text = day,
+                        style = AdegoTheme.typography.bodySmall,
+                        color = AdegoTheme.colors.onBackground,
+                        modifier = Modifier.weight(1f),
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Calendar Grid
+            val cal = Calendar.getInstance().apply {
+                set(Calendar.YEAR, currentYear)
+                set(Calendar.MONTH, currentMonth)
+                set(Calendar.DAY_OF_MONTH, 1)
+            }
+
+            val firstDayOfWeek = cal.get(Calendar.DAY_OF_WEEK) - 1
+            val daysInMonth = cal.getActualMaximum(Calendar.DAY_OF_MONTH)
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                var dayCounter = 1 - firstDayOfWeek
+
+                repeat(6) { weekIndex ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceEvenly
+                    ) {
+                        repeat(7) { dayOfWeek ->
+                            val day = dayCounter
+                            dayCounter++
+
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .size(40.dp)
+                                    .clip(CircleShape)
+                                    .then(
+                                        if (day in 1..daysInMonth) {
+                                            val thisDateCal = Calendar.getInstance().apply {
+                                                set(Calendar.YEAR, currentYear)
+                                                set(Calendar.MONTH, currentMonth)
+                                                set(Calendar.DAY_OF_MONTH, day)
+                                                set(Calendar.HOUR_OF_DAY, 0)
+                                                set(Calendar.MINUTE, 0)
+                                                set(Calendar.SECOND, 0)
+                                                set(Calendar.MILLISECOND, 0)
+                                            }
+                                            val isSelected = selectedDateMillis?.let {
+                                                val selectedCal = Calendar.getInstance().apply {
+                                                    timeInMillis = it
+                                                    set(Calendar.HOUR_OF_DAY, 0)
+                                                    set(Calendar.MINUTE, 0)
+                                                    set(Calendar.SECOND, 0)
+                                                    set(Calendar.MILLISECOND, 0)
+                                                }
+                                                thisDateCal.timeInMillis == selectedCal.timeInMillis
+                                            } ?: false
+
+                                            Modifier
+                                                .background(
+                                                    if (isSelected) AdegoTheme.colors.main500 else Color.Transparent,
+                                                    CircleShape
+                                                )
+                                                .clickable {
+                                                    selectedDateMillis = thisDateCal.timeInMillis
+                                                }
+                                        } else {
+                                            Modifier
+                                        }
+                                    ),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                if (day in 1..daysInMonth) {
+                                    val thisDateCal = Calendar.getInstance().apply {
+                                        set(Calendar.YEAR, currentYear)
+                                        set(Calendar.MONTH, currentMonth)
+                                        set(Calendar.DAY_OF_MONTH, day)
+                                        set(Calendar.HOUR_OF_DAY, 0)
+                                        set(Calendar.MINUTE, 0)
+                                        set(Calendar.SECOND, 0)
+                                        set(Calendar.MILLISECOND, 0)
+                                    }
+                                    val isSelected = selectedDateMillis?.let {
+                                        val selectedCal = Calendar.getInstance().apply {
+                                            timeInMillis = it
+                                            set(Calendar.HOUR_OF_DAY, 0)
+                                            set(Calendar.MINUTE, 0)
+                                            set(Calendar.SECOND, 0)
+                                            set(Calendar.MILLISECOND, 0)
+                                        }
+                                        thisDateCal.timeInMillis == selectedCal.timeInMillis
+                                    } ?: false
+
+                                    Text(
+                                        text = day.toString(),
+                                        style = AdegoTheme.typography.bodySmall,
+                                        color = if (isSelected) Color.White else AdegoTheme.colors.onBackground,
+                                        textAlign = TextAlign.Center
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Confirm Button
+            Button(
+                onClick = {
+                    onConfirm(selectedDateMillis)
+                    onDismiss()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = AdegoTheme.colors.main500
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text(
+                    text = "날짜 선택",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = Color.White
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = Color.White
+                )
+            }
+        }
+    }
+}

--- a/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/component/AdegoTimePicker.kt
+++ b/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/component/AdegoTimePicker.kt
@@ -1,0 +1,285 @@
+package com.teammanduk.adego.core.designsystem.component
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.launch
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun AdegoTimePicker(
+    show: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (hour: Int, minute: Int) -> Unit,
+    initialHour: Int = 0,
+    initialMinute: Int = 0
+) {
+    if (!show) return
+
+    // initialHour (0-23) -> selectedHour (0-11, 0=12시)
+    val initialHour12 = initialHour % 12
+    var selectedHour by remember { mutableIntStateOf(initialHour12) }
+    var selectedMinute by remember { mutableIntStateOf(initialMinute) }
+    var isPM by remember { mutableStateOf(initialHour >= 12) }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .background(Color.White, RoundedCornerShape(16.dp))
+                .padding(24.dp)
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "시간 선택",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = AdegoTheme.colors.onBackground,
+                    modifier = Modifier.weight(1f)
+                )
+
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "닫기",
+                        tint = AdegoTheme.colors.onBackground
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Time Picker
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // AM/PM Picker
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(60.dp, 40.dp)
+                            .background(
+                                color = if (!isPM) AdegoTheme.colors.main500 else Color.Transparent,
+                                shape = RoundedCornerShape(8.dp)
+                            )
+                            .clickable { isPM = false },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "AM",
+                            style = AdegoTheme.typography.bodyLarge,
+                            color = if (!isPM) Color.White else AdegoTheme.colors.onBackground
+                        )
+                    }
+
+                    Box(
+                        modifier = Modifier
+                            .size(60.dp, 40.dp)
+                            .background(
+                                color = if (isPM) AdegoTheme.colors.main500 else Color.Transparent,
+                                shape = RoundedCornerShape(8.dp)
+                            )
+                            .clickable { isPM = true },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "PM",
+                            style = AdegoTheme.typography.bodyLarge,
+                            color = if (isPM) Color.White else AdegoTheme.colors.onBackground
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(16.dp))
+
+                // Hour Picker
+                ScrollableTimePickerColumn(
+                    value = selectedHour,
+                    onValueChange = { selectedHour = it },
+                    range = 0..11,
+                    displayRange = 1..12
+                )
+
+                Text(
+                    text = ":",
+                    style = AdegoTheme.typography.headlineLarge,
+                    color = AdegoTheme.colors.onBackground,
+                    modifier = Modifier.padding(horizontal = 8.dp)
+                )
+
+                // Minute Picker
+                ScrollableTimePickerColumn(
+                    value = selectedMinute,
+                    onValueChange = { selectedMinute = it },
+                    range = 0..59,
+                    displayRange = 0..59
+                )
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Confirm Button
+            Button(
+                onClick = {
+                    // selectedHour: 0=12시, 1=1시, 2=2시, ..., 11=11시
+                    val hour12 = if (selectedHour == 0) 12 else selectedHour
+                    val hour24 = if (isPM) {
+                        if (hour12 == 12) 12 else hour12 + 12
+                    } else {
+                        if (hour12 == 12) 0 else hour12
+                    }
+                    onConfirm(hour24, selectedMinute)
+                    onDismiss()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = AdegoTheme.colors.main500
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text(
+                    text = "시간 선택",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = Color.White
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = Color.White
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ScrollableTimePickerColumn(
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    range: IntRange,
+    displayRange: IntRange
+) {
+    val itemCount = range.count()
+    val repeatCount = 1000
+    val totalItems = itemCount * repeatCount
+    val middleStart = totalItems / 2 - (totalItems / 2) % itemCount
+
+    val listState = rememberLazyListState(
+        initialFirstVisibleItemIndex = middleStart + value
+    )
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex }
+            .map { index -> index % itemCount }
+            .distinctUntilChanged()
+            .collect { normalizedIndex ->
+                onValueChange(normalizedIndex)
+            }
+    }
+
+    Box(
+        modifier = Modifier
+            .width(80.dp)
+            .height(180.dp)
+    ) {
+        LazyColumn(
+            state = listState,
+            flingBehavior = rememberSnapFlingBehavior(lazyListState = listState),
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 60.dp)
+        ) {
+            items(totalItems) { index ->
+                val itemValue = index % itemCount
+                // displayRange가 1..12면 itemValue 0 -> 12, 1 -> 1, ..., 11 -> 11
+                val displayValue = if (displayRange.first == 1) {
+                    if (itemValue == 0) 12 else itemValue
+                } else {
+                    itemValue
+                }
+                val isSelected = itemValue == value
+
+                Box(
+                    modifier = Modifier
+                        .height(60.dp)
+                        .fillMaxWidth()
+                        .clickable {
+                            coroutineScope.launch {
+                                listState.animateScrollToItem(index)
+                            }
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = String.format("%02d", displayValue),
+                        style = AdegoTheme.typography.headlineLarge,
+                        color = if (isSelected) AdegoTheme.colors.main500 else AdegoTheme.colors.onBackground.copy(alpha = 0.3f),
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        }
+
+        // Highlight box
+        Box(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .size(80.dp, 60.dp)
+                .background(
+                    color = AdegoTheme.colors.main500.copy(alpha = 0.1f),
+                    shape = RoundedCornerShape(8.dp)
+                )
+        )
+    }
+}

--- a/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/ui/theme/Color.kt
+++ b/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/ui/theme/Color.kt
@@ -2,10 +2,104 @@ package com.teammanduk.adego.core.designsystem.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+// Main colors
+val Main100 = Color(0xFFB5EBD7)
+val Main500 = Color(0xFF3ECF8E)
+val Main900 = Color(0xFF1F7A50)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val OnMain100 = Color(0xFF2D6A4F)
+val OnMain500 = Color(0xFFFFFFFF)
+val OnMain900 = Color(0xFFFFFFFF)
+
+// Highlight colors
+val Highlight100 = Color(0xFFB3D9FF)
+val Highlight500 = Color(0xFF4A9FFF)
+val Highlight900 = Color(0xFF1E5A8E)
+
+val OnHighlight100 = Color(0xFF1E4D7B)
+val OnHighlight500 = Color(0xFFFFFFFF)
+val OnHighlight900 = Color(0xFFFFFFFF)
+
+// Error colors
+val Error100 = Color(0xFFFFB4B4)
+val Error500 = Color(0xFFFF6B6B)
+val Error900 = Color(0xFF8B0000)
+
+val OnError100 = Color(0xFF8B0000)
+val OnError500 = Color(0xFFFFFFFF)
+val OnError900 = Color(0xFFFFFFFF)
+
+// Background & Surface
+val Background = Color(0xFFE8F5F0)
+val OnBackground = Color(0xFF000000)
+val Surface = Color(0xFFFFFFFF)
+val OnSurface = Color(0xFF000000)
+
+// Line colors
+val Line100 = Color(0xFFE8E8E8)
+val Line500 = Color(0xFFB0B0B0)
+val Line900 = Color(0xFF707070)
+
+interface AdegoColor {
+    val main100: Color
+    val main500: Color
+    val main900: Color
+    val onMain100: Color
+    val onMain500: Color
+    val onMain900: Color
+
+    val highlight100: Color
+    val highlight500: Color
+    val highlight900: Color
+    val onHighlight100: Color
+    val onHighlight500: Color
+    val onHighlight900: Color
+
+    val error100: Color
+    val error500: Color
+    val error900: Color
+    val onError100: Color
+    val onError500: Color
+    val onError900: Color
+
+    val background: Color
+    val onBackground: Color
+    val surface: Color
+    val onSurface: Color
+
+    val line100: Color
+    val line500: Color
+    val line900: Color
+}
+
+internal object AdegoLightColor : AdegoColor {
+    override val main100 = Main100
+    override val main500 = Main500
+    override val main900 = Main900
+    override val onMain100 = OnMain100
+    override val onMain500 = OnMain500
+    override val onMain900 = OnMain900
+
+    override val highlight100 = Highlight100
+    override val highlight500 = Highlight500
+    override val highlight900 = Highlight900
+    override val onHighlight100 = OnHighlight100
+    override val onHighlight500 = OnHighlight500
+    override val onHighlight900 = OnHighlight900
+
+    override val error100 = Error100
+    override val error500 = Error500
+    override val error900 = Error900
+    override val onError100 = OnError100
+    override val onError500 = OnError500
+    override val onError900 = OnError900
+
+    override val background = Background
+    override val onBackground = OnBackground
+    override val surface = Surface
+    override val onSurface = OnSurface
+
+    override val line100 = Line100
+    override val line500 = Line500
+    override val line900 = Line900
+}

--- a/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/ui/theme/LocalColor.kt
+++ b/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/ui/theme/LocalColor.kt
@@ -1,0 +1,7 @@
+package com.teammanduk.adego.core.designsystem.ui.theme
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+internal val LocalColor = staticCompositionLocalOf<AdegoColor> {
+    error("LocalColor가 제공되지 않았습니다. AdegoTheme를 적용했는지 확인해주세요.")
+}

--- a/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/ui/theme/LocalTypography.kt
+++ b/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/ui/theme/LocalTypography.kt
@@ -1,0 +1,7 @@
+package com.teammanduk.adego.core.designsystem.ui.theme
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+internal val LocalTypography = staticCompositionLocalOf<AdegoTypography> {
+    error("LocalTypography가 제공되지 않았습니다. AdegoTheme를 적용했는지 확인해주세요.")
+}

--- a/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/ui/theme/Theme.kt
+++ b/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/ui/theme/Theme.kt
@@ -1,57 +1,52 @@
 package com.teammanduk.adego.core.designsystem.ui.theme
 
+import android.app.Activity
 import android.os.Build
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.lightColorScheme
+import android.view.Window
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
-)
-
-private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
-)
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 @Composable
 fun AdegoTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
+    val colors = remember { AdegoLightColor }
 
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+    val view = LocalView.current
+    val window = (view.context as? Activity)?.window
+
+    SideEffect {
+        window?.let {
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+            window.setSystemBarBackground()
+        }
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
+    CompositionLocalProvider(
+        LocalColor provides colors,
+        LocalTypography provides AdegoTypography,
         content = content
     )
+}
+
+private fun Window.setSystemBarBackground() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        this.isNavigationBarContrastEnforced = false
+    }
+
+    this.statusBarColor = Color.Transparent.toArgb()
+    this.navigationBarColor = Color.Transparent.toArgb()
+}
+
+object AdegoTheme {
+    val colors: AdegoColor
+        @Composable get() = LocalColor.current
+    val typography: AdegoTypography
+        @Composable get() = LocalTypography.current
 }

--- a/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/ui/theme/Type.kt
+++ b/core/designsystem/src/main/kotlin/com/teammanduk/adego/core/designsystem/ui/theme/Type.kt
@@ -1,34 +1,47 @@
 package com.teammanduk.adego.core.designsystem.ui.theme
 
-import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
-val Typography = Typography(
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
+object AdegoTypography {
+    val headlineLarge = TextStyle(
+        fontSize = 24.sp,
+        fontWeight = FontWeight.SemiBold
+    )
+
+    val headlineSmall = TextStyle(
+        fontSize = 20.sp,
+        fontWeight = FontWeight.SemiBold
+    )
+
+    val titleLarge = TextStyle(
+        fontSize = 18.sp,
+        fontWeight = FontWeight.Medium
+    )
+
+    val titleSmall = TextStyle(
         fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
+        fontWeight = FontWeight.Medium
     )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
-    ),
-    labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.5.sp
+
+    val bodyLarge = TextStyle(
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Normal
     )
-    */
-)
+
+    val bodySmall = TextStyle(
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Normal
+    )
+
+    val labelLarge = TextStyle(
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Medium
+    )
+
+    val labelSmall = TextStyle(
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Medium
+    )
+}

--- a/core/navigation/src/main/kotlin/com/teammanduk/adego/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/kotlin/com/teammanduk/adego/core/navigation/RouteModel.kt
@@ -13,5 +13,8 @@ sealed interface Route {
     data object SelectPlace: Route
 
     @Serializable
-    data object Map: Route
+    data class Map(
+        val hour: Int,
+        val minute: Int
+    ): Route
 }

--- a/feature/create/src/main/java/com/teammanduk/adego/feature/create/CreateScreen.kt
+++ b/feature/create/src/main/java/com/teammanduk/adego/feature/create/CreateScreen.kt
@@ -3,7 +3,6 @@ package com.teammanduk.adego.feature.create
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,10 +10,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.outlined.DateRange
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -23,9 +27,11 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,18 +39,25 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.teammanduk.adego.core.designsystem.component.AdegoDatePicker
+import com.teammanduk.adego.core.designsystem.component.AdegoTimePicker
 import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 @Composable
 internal fun CreateRoute(
     onNavigateBack: () -> Unit = {},
     onNavigateToSelectPlace: () -> Unit = {},
     onCreateMeeting: (String, Int, Int) -> Unit = { _, _, _ -> },
+    selectedPlaceFromNav: String? = null,
 ) {
     CreateScreen(
         onNavigateBack = onNavigateBack,
         onNavigateToSelectPlace = onNavigateToSelectPlace,
         onCreateMeeting = onCreateMeeting,
+        selectedPlaceFromNav = selectedPlaceFromNav,
     )
 }
 
@@ -53,14 +66,28 @@ private fun CreateScreen(
     onNavigateBack: () -> Unit,
     onNavigateToSelectPlace: () -> Unit,
     onCreateMeeting: (String, Int, Int) -> Unit,
+    selectedPlaceFromNav: String? = null,
 ) {
-    var selectedPlace by remember { mutableStateOf("") }
-    var selectedHour by remember { mutableStateOf("") }
-    var selectedMinute by remember { mutableStateOf("") }
+    var selectedPlace by rememberSaveable { mutableStateOf("") }
+
+    // Navigation에서 전달받은 장소 정보 업데이트
+    LaunchedEffect(selectedPlaceFromNav) {
+        selectedPlaceFromNav?.let {
+            if (it.isNotEmpty()) {
+                selectedPlace = it
+            }
+        }
+    }
+    var selectedDate by rememberSaveable { mutableStateOf<Long?>(null) }
+    var selectedHour by rememberSaveable { mutableStateOf<Int?>(null) }
+    var selectedMinute by rememberSaveable { mutableStateOf<Int?>(null) }
+    var showDatePicker by rememberSaveable { mutableStateOf(false) }
+    var showTimePicker by rememberSaveable { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .systemBarsPadding()
             .background(AdegoTheme.colors.background)
     ) {
         // 상단 바
@@ -96,13 +123,16 @@ private fun CreateScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // 타이틀
+            val dateFormat = SimpleDateFormat("MM월 dd일", Locale.KOREAN)
+            val displayDate = selectedDate?.let { dateFormat.format(Date(it)) } ?: "날짜 선택"
+            val displayTime = if (selectedHour != null && selectedMinute != null) {
+                String.format("%02d시 %02d분", selectedHour, selectedMinute)
+            } else {
+                "00시 00분"
+            }
+
             Text(
-                text = buildString {
-                    append(selectedHour.ifEmpty { "00" })
-                    append("시 ")
-                    append(selectedMinute.ifEmpty { "00" })
-                    append("분 모임 시작!")
-                },
+                text = "$displayTime 모임 시작!",
                 style = AdegoTheme.typography.headlineLarge,
                 color = AdegoTheme.colors.main500,
                 textAlign = TextAlign.Center
@@ -127,12 +157,31 @@ private fun CreateScreen(
                     onValueChange = { },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { onNavigateToSelectPlace() },
+                        .clickable {
+                            onNavigateToSelectPlace()
+                        },
                     enabled = false,
+                    placeholder = {
+                        Text(
+                            text = "모임 장소를 선택해 주세요",
+                            style = AdegoTheme.typography.bodyLarge,
+                            color = AdegoTheme.colors.line500
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.LocationOn,
+                            contentDescription = null,
+                            tint = AdegoTheme.colors.main500,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    },
                     colors = OutlinedTextFieldDefaults.colors(
                         disabledBorderColor = AdegoTheme.colors.main500,
                         disabledContainerColor = Color.Transparent,
                         disabledTextColor = AdegoTheme.colors.onBackground,
+                        disabledPlaceholderColor = AdegoTheme.colors.line500,
+                        disabledLeadingIconColor = AdegoTheme.colors.main500
                     ),
                     shape = RoundedCornerShape(8.dp)
                 )
@@ -156,56 +205,70 @@ private fun CreateScreen(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
+                    // 날짜 선택
                     OutlinedTextField(
-                        value = selectedHour,
-                        onValueChange = {
-                            if (it.isEmpty() || (it.toIntOrNull() != null && it.toInt() in 0..23)) {
-                                selectedHour = it
-                            }
-                        },
-                        modifier = Modifier.weight(1f),
+                        value = if (selectedDate != null) displayDate else "",
+                        onValueChange = { },
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable { showDatePicker = true },
+                        enabled = false,
                         placeholder = {
                             Text(
-                                text = "시",
+                                text = "날짜 선택",
+                                style = AdegoTheme.typography.bodyLarge,
                                 color = AdegoTheme.colors.line500
                             )
                         },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.DateRange,
+                                contentDescription = null,
+                                tint = AdegoTheme.colors.main500,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        },
                         colors = OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = AdegoTheme.colors.main500,
-                            unfocusedBorderColor = AdegoTheme.colors.main500,
-                            focusedContainerColor = Color.Transparent,
-                            unfocusedContainerColor = Color.Transparent,
+                            disabledBorderColor = AdegoTheme.colors.main500,
+                            disabledContainerColor = Color.Transparent,
+                            disabledTextColor = AdegoTheme.colors.onBackground,
+                            disabledPlaceholderColor = AdegoTheme.colors.line500,
+                            disabledLeadingIconColor = AdegoTheme.colors.main500
                         ),
-                        shape = RoundedCornerShape(8.dp),
-                        textStyle = AdegoTheme.typography.bodyLarge.copy(
-                            textAlign = TextAlign.Center
-                        )
+                        shape = RoundedCornerShape(8.dp)
                     )
 
+                    // 시간 선택
                     OutlinedTextField(
-                        value = selectedMinute,
-                        onValueChange = {
-                            if (it.isEmpty() || (it.toIntOrNull() != null && it.toInt() in 0..59)) {
-                                selectedMinute = it
-                            }
-                        },
-                        modifier = Modifier.weight(1f),
+                        value = if (selectedHour != null && selectedMinute != null) displayTime else "",
+                        onValueChange = { },
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable { showTimePicker = true },
+                        enabled = false,
                         placeholder = {
                             Text(
-                                text = "분",
+                                text = "시간 선택",
+                                style = AdegoTheme.typography.bodyLarge,
                                 color = AdegoTheme.colors.line500
                             )
                         },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Search,
+                                contentDescription = null,
+                                tint = AdegoTheme.colors.main500,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        },
                         colors = OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = AdegoTheme.colors.main500,
-                            unfocusedBorderColor = AdegoTheme.colors.main500,
-                            focusedContainerColor = Color.Transparent,
-                            unfocusedContainerColor = Color.Transparent,
+                            disabledBorderColor = AdegoTheme.colors.main500,
+                            disabledContainerColor = Color.Transparent,
+                            disabledTextColor = AdegoTheme.colors.onBackground,
+                            disabledPlaceholderColor = AdegoTheme.colors.line500,
+                            disabledLeadingIconColor = AdegoTheme.colors.main500
                         ),
-                        shape = RoundedCornerShape(8.dp),
-                        textStyle = AdegoTheme.typography.bodyLarge.copy(
-                            textAlign = TextAlign.Center
-                        )
+                        shape = RoundedCornerShape(8.dp)
                     )
                 }
             }
@@ -215,19 +278,19 @@ private fun CreateScreen(
             // 모임 생성하기 버튼
             Button(
                 onClick = {
-                    val hour = selectedHour.toIntOrNull() ?: 0
-                    val minute = selectedMinute.toIntOrNull() ?: 0
+                    val hour = selectedHour ?: 0
+                    val minute = selectedMinute ?: 0
                     onCreateMeeting(selectedPlace, hour, minute)
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(56.dp)
-                    .padding(bottom = 32.dp),
+                    .padding(bottom = 32.dp)
+                    .height(56.dp),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = AdegoTheme.colors.main500
                 ),
                 shape = RoundedCornerShape(12.dp),
-                enabled = selectedPlace.isNotEmpty() && selectedHour.isNotEmpty() && selectedMinute.isNotEmpty()
+                enabled = selectedPlace.isNotEmpty() && selectedDate != null && selectedHour != null && selectedMinute != null
             ) {
                 Text(
                     text = "모임 생성하기",
@@ -237,6 +300,26 @@ private fun CreateScreen(
             }
         }
     }
+
+    // DatePicker
+    AdegoDatePicker(
+        show = showDatePicker,
+        onDismiss = { showDatePicker = false },
+        onConfirm = { selectedDate = it },
+        initialDate = selectedDate
+    )
+
+    // TimePicker
+    AdegoTimePicker(
+        show = showTimePicker,
+        onDismiss = { showTimePicker = false },
+        onConfirm = { hour, minute ->
+            selectedHour = hour
+            selectedMinute = minute
+        },
+        initialHour = selectedHour ?: 0,
+        initialMinute = selectedMinute ?: 0
+    )
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/feature/create/src/main/java/com/teammanduk/adego/feature/create/CreateScreen.kt
+++ b/feature/create/src/main/java/com/teammanduk/adego/feature/create/CreateScreen.kt
@@ -1,26 +1,252 @@
 package com.teammanduk.adego.feature.create
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
 
 @Composable
-internal fun CreateRoute() {
-    CreateScreen()
+internal fun CreateRoute(
+    onNavigateBack: () -> Unit = {},
+    onNavigateToSelectPlace: () -> Unit = {},
+    onCreateMeeting: (String, Int, Int) -> Unit = { _, _, _ -> },
+) {
+    CreateScreen(
+        onNavigateBack = onNavigateBack,
+        onNavigateToSelectPlace = onNavigateToSelectPlace,
+        onCreateMeeting = onCreateMeeting,
+    )
 }
 
 @Composable
-private fun CreateScreen() {
-    Box(
+private fun CreateScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToSelectPlace: () -> Unit,
+    onCreateMeeting: (String, Int, Int) -> Unit,
+) {
+    var selectedPlace by remember { mutableStateOf("") }
+    var selectedHour by remember { mutableStateOf("") }
+    var selectedMinute by remember { mutableStateOf("") }
+
+    Column(
         modifier = Modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.Center
+            .fillMaxSize()
+            .background(AdegoTheme.colors.background)
     ) {
-        Text(
-            text = "모임 생성"
+        // 상단 바
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onNavigateBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "뒤로가기",
+                    tint = AdegoTheme.colors.onBackground
+                )
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Text(
+                text = "모임 생성",
+                style = AdegoTheme.typography.titleLarge,
+                color = AdegoTheme.colors.onBackground
+            )
+        }
+
+        // 메인 컨텐츠
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 32.dp)
+                .padding(top = 40.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // 타이틀
+            Text(
+                text = buildString {
+                    append(selectedHour.ifEmpty { "00" })
+                    append("시 ")
+                    append(selectedMinute.ifEmpty { "00" })
+                    append("분 모임 시작!")
+                },
+                style = AdegoTheme.typography.headlineLarge,
+                color = AdegoTheme.colors.main500,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            // 장소 선택
+            Column(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = "장소 선택",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = AdegoTheme.colors.main500
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                OutlinedTextField(
+                    value = selectedPlace,
+                    onValueChange = { },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onNavigateToSelectPlace() },
+                    enabled = false,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        disabledBorderColor = AdegoTheme.colors.main500,
+                        disabledContainerColor = Color.Transparent,
+                        disabledTextColor = AdegoTheme.colors.onBackground,
+                    ),
+                    shape = RoundedCornerShape(8.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // 시간 선택
+            Column(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = "시간 선택",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = AdegoTheme.colors.main500
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    OutlinedTextField(
+                        value = selectedHour,
+                        onValueChange = {
+                            if (it.isEmpty() || (it.toIntOrNull() != null && it.toInt() in 0..23)) {
+                                selectedHour = it
+                            }
+                        },
+                        modifier = Modifier.weight(1f),
+                        placeholder = {
+                            Text(
+                                text = "시",
+                                color = AdegoTheme.colors.line500
+                            )
+                        },
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = AdegoTheme.colors.main500,
+                            unfocusedBorderColor = AdegoTheme.colors.main500,
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                        ),
+                        shape = RoundedCornerShape(8.dp),
+                        textStyle = AdegoTheme.typography.bodyLarge.copy(
+                            textAlign = TextAlign.Center
+                        )
+                    )
+
+                    OutlinedTextField(
+                        value = selectedMinute,
+                        onValueChange = {
+                            if (it.isEmpty() || (it.toIntOrNull() != null && it.toInt() in 0..59)) {
+                                selectedMinute = it
+                            }
+                        },
+                        modifier = Modifier.weight(1f),
+                        placeholder = {
+                            Text(
+                                text = "분",
+                                color = AdegoTheme.colors.line500
+                            )
+                        },
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = AdegoTheme.colors.main500,
+                            unfocusedBorderColor = AdegoTheme.colors.main500,
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                        ),
+                        shape = RoundedCornerShape(8.dp),
+                        textStyle = AdegoTheme.typography.bodyLarge.copy(
+                            textAlign = TextAlign.Center
+                        )
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // 모임 생성하기 버튼
+            Button(
+                onClick = {
+                    val hour = selectedHour.toIntOrNull() ?: 0
+                    val minute = selectedMinute.toIntOrNull() ?: 0
+                    onCreateMeeting(selectedPlace, hour, minute)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .padding(bottom = 32.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = AdegoTheme.colors.main500
+                ),
+                shape = RoundedCornerShape(12.dp),
+                enabled = selectedPlace.isNotEmpty() && selectedHour.isNotEmpty() && selectedMinute.isNotEmpty()
+            ) {
+                Text(
+                    text = "모임 생성하기",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = AdegoTheme.colors.onMain500
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+private fun CreateScreenPreview() {
+    AdegoTheme {
+        CreateScreen(
+            onNavigateBack = {},
+            onNavigateToSelectPlace = {},
+            onCreateMeeting = { _, _, _ -> },
         )
     }
 }

--- a/feature/create/src/main/java/com/teammanduk/adego/feature/create/SelectPlaceScreen.kt
+++ b/feature/create/src/main/java/com/teammanduk/adego/feature/create/SelectPlaceScreen.kt
@@ -1,26 +1,154 @@
 package com.teammanduk.adego.feature.create
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
 
 @Composable
-internal fun SelectPlaceRoute() {
-    SelectPlaceScreen()
+internal fun SelectPlaceRoute(
+    onBackClick: () -> Unit = {},
+    onPlaceSelected: () -> Unit = {}
+) {
+    SelectPlaceScreen(
+        onBackClick = onBackClick,
+        onPlaceSelected = onPlaceSelected
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SelectPlaceScreen(
+    onBackClick: () -> Unit,
+    onPlaceSelected: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "모임 장소 선택",
+                        style = AdegoTheme.typography.titleLarge
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "뒤로가기"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            // 지도 Placeholder
+            MapPlaceholder(
+                modifier = Modifier.fillMaxSize()
+            )
+
+            // 하단 장소 정보 카드 + 버튼
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                PlaceInfoCard(
+                    placeName = "부산 북구 만덕대로 291",
+                    placeAddress = "부산 북구 만덕동 607-1"
+                )
+
+                Button(
+                    onClick = onPlaceSelected,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = AdegoTheme.colors.main500
+                    ),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Text(
+                        text = "모임 장소 선택하기",
+                        style = AdegoTheme.typography.titleLarge,
+                        color = AdegoTheme.colors.onMain500
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Composable
-private fun SelectPlaceScreen() {
+private fun MapPlaceholder(
+    modifier: Modifier = Modifier
+) {
     Box(
-        modifier = Modifier
-            .fillMaxSize(),
+        modifier = modifier
+            .background(Color(0xFFE0E0E0)),
         contentAlignment = Alignment.Center
     ) {
+        Icon(
+            imageVector = Icons.Default.LocationOn,
+            contentDescription = "지도 영역",
+            tint = Color(0xFF757575),
+            modifier = Modifier.padding(32.dp)
+        )
+    }
+}
+
+@Composable
+private fun PlaceInfoCard(
+    placeName: String,
+    placeAddress: String
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = Color.White,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
         Text(
-            text = "모임 장소 선택"
+            text = placeName,
+            style = AdegoTheme.typography.titleLarge
+        )
+        Text(
+            text = placeAddress,
+            style = AdegoTheme.typography.bodySmall,
+            color = Color(0xFF757575)
         )
     }
 }

--- a/feature/create/src/main/java/com/teammanduk/adego/feature/create/navigation/CreateNavigation.kt
+++ b/feature/create/src/main/java/com/teammanduk/adego/feature/create/navigation/CreateNavigation.kt
@@ -6,7 +6,6 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.teammanduk.adego.core.navigation.Route
 import com.teammanduk.adego.feature.create.CreateRoute
-import com.teammanduk.adego.feature.create.SelectPlaceRoute
 
 fun NavController.navigateToCreate(
     navOptions: NavOptions? = null
@@ -14,18 +13,16 @@ fun NavController.navigateToCreate(
     navigate(Route.Create, navOptions)
 }
 
-fun NavController.navigateToSelectPlace(
-    navOptions: NavOptions? = null
+fun NavGraphBuilder.createNavGraph(
+    onNavigateBack: () -> Unit,
+    onNavigateToSelectPlace: () -> Unit,
+    onCreateMeeting: (String, Int, Int) -> Unit,
 ) {
-    navigate(Route.SelectPlace, navOptions)
-}
-
-fun NavGraphBuilder.createNavGraph() {
     composable<Route.Create> {
-        CreateRoute()
-    }
-
-    composable<Route.SelectPlace> {
-        SelectPlaceRoute()
+        CreateRoute(
+            onNavigateBack = onNavigateBack,
+            onNavigateToSelectPlace = onNavigateToSelectPlace,
+            onCreateMeeting = onCreateMeeting,
+        )
     }
 }

--- a/feature/create/src/main/java/com/teammanduk/adego/feature/create/navigation/CreateNavigation.kt
+++ b/feature/create/src/main/java/com/teammanduk/adego/feature/create/navigation/CreateNavigation.kt
@@ -1,11 +1,13 @@
 package com.teammanduk.adego.feature.create.navigation
 
+import androidx.compose.runtime.collectAsState
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.teammanduk.adego.core.navigation.Route
 import com.teammanduk.adego.feature.create.CreateRoute
+import com.teammanduk.adego.feature.create.SelectPlaceRoute
 
 fun NavController.navigateToCreate(
     navOptions: NavOptions? = null
@@ -20,15 +22,40 @@ fun NavController.navigateToSelectPlace(
 }
 
 fun NavGraphBuilder.createNavGraph(
+    navController: NavController,
     onNavigateBack: () -> Unit,
     onNavigateToSelectPlace: () -> Unit,
     onCreateMeeting: (String, Int, Int) -> Unit,
 ) {
-    composable<Route.Create> {
+    composable<Route.Create> { backStackEntry ->
+        val selectedPlace = navController.currentBackStackEntry
+            ?.savedStateHandle
+            ?.getStateFlow("selected_place", "")
+            ?.collectAsState()
+
         CreateRoute(
             onNavigateBack = onNavigateBack,
             onNavigateToSelectPlace = onNavigateToSelectPlace,
             onCreateMeeting = onCreateMeeting,
+            selectedPlaceFromNav = selectedPlace?.value,
+        )
+    }
+
+    composable<Route.SelectPlace> {
+        SelectPlaceRoute(
+            onBackClick = onNavigateBack,
+            onPlaceSelected = {
+                // TODO: ViewModel/Repository 구현 시
+                // - CreateViewModel의 StateFlow에 선택된 장소 정보 업데이트
+                // - CreateScreen에서 StateFlow를 관찰하여 자동으로 UI 업데이트
+                // 예: viewModel.updateSelectedPlace(placeName, placeAddress)
+
+                // 임시: 이전 화면(Create)의 savedStateHandle에 장소 정보 저장 (테스트용)
+                navController.previousBackStackEntry
+                    ?.savedStateHandle
+                    ?.set("selected_place", "부산 북구 만덕대로 291")
+                onNavigateBack()
+            }
         )
     }
 }

--- a/feature/create/src/main/java/com/teammanduk/adego/feature/create/navigation/CreateNavigation.kt
+++ b/feature/create/src/main/java/com/teammanduk/adego/feature/create/navigation/CreateNavigation.kt
@@ -13,6 +13,12 @@ fun NavController.navigateToCreate(
     navigate(Route.Create, navOptions)
 }
 
+fun NavController.navigateToSelectPlace(
+    navOptions: NavOptions? = null
+) {
+    navigate(Route.SelectPlace, navOptions)
+}
+
 fun NavGraphBuilder.createNavGraph(
     onNavigateBack: () -> Unit,
     onNavigateToSelectPlace: () -> Unit,

--- a/feature/home/src/main/java/com/teammanduk/adego/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teammanduk/adego/feature/home/HomeScreen.kt
@@ -155,7 +155,8 @@ private fun HomeScreen(
                     colors = ButtonDefaults.buttonColors(
                         containerColor = AdegoTheme.colors.main500
                     ),
-                    shape = RoundedCornerShape(8.dp)
+                    shape = RoundedCornerShape(8.dp),
+                    enabled = inviteCode.isNotEmpty()
                 ) {
                     Text(
                         text = "입장",

--- a/feature/home/src/main/java/com/teammanduk/adego/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teammanduk/adego/feature/home/HomeScreen.kt
@@ -1,26 +1,190 @@
 package com.teammanduk.adego.feature.home
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
 
 @Composable
-internal fun HomeRoute() {
-    HomeScreen()
+internal fun HomeRoute(
+    onNavigateToCreate: () -> Unit = {},
+    onNavigateToSettings: () -> Unit = {},
+    onJoinWithCode: (String) -> Unit = {},
+) {
+    HomeScreen(
+        onNavigateToCreate = onNavigateToCreate,
+        onNavigateToSettings = onNavigateToSettings,
+        onJoinWithCode = onJoinWithCode,
+    )
 }
 
 @Composable
-private fun HomeScreen() {
+private fun HomeScreen(
+    onNavigateToCreate: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    onJoinWithCode: (String) -> Unit,
+) {
+    var inviteCode by remember { mutableStateOf("") }
+
     Box(
         modifier = Modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.Center
+            .fillMaxSize()
+            .background(AdegoTheme.colors.background)
     ) {
-        Text(
-            text = "Home Screen"
+        // 설정 아이콘
+        IconButton(
+            onClick = onNavigateToSettings,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(16.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Settings,
+                contentDescription = "설정",
+                tint = AdegoTheme.colors.main900
+            )
+        }
+
+        // 메인 컨텐츠
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            // 타이틀
+            Text(
+                text = "지금 만나기로 했나요?",
+                style = AdegoTheme.typography.headlineLarge,
+                color = AdegoTheme.colors.main500
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 서브타이틀
+            Text(
+                text = "바로 시작해 보세요",
+                style = AdegoTheme.typography.bodyLarge,
+                color = AdegoTheme.colors.onBackground
+            )
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            // 새 모임 만들기 버튼
+            Button(
+                onClick = onNavigateToCreate,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = AdegoTheme.colors.main500
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text(
+                    text = "+ 새 모임 만들기",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = AdegoTheme.colors.onMain500
+                )
+            }
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            // 초대 코드로 시작하기
+            Text(
+                text = "초대 코드로 시작하기",
+                style = AdegoTheme.typography.titleLarge,
+                color = AdegoTheme.colors.main500,
+                modifier = Modifier.align(Alignment.Start)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 코드 입력 및 입장 버튼
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedTextField(
+                    value = inviteCode,
+                    onValueChange = { inviteCode = it },
+                    modifier = Modifier.weight(1f),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = AdegoTheme.colors.main500,
+                        unfocusedBorderColor = AdegoTheme.colors.main500,
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                    ),
+                    shape = RoundedCornerShape(8.dp)
+                )
+
+                Button(
+                    onClick = { onJoinWithCode(inviteCode) },
+                    modifier = Modifier
+                        .width(80.dp)
+                        .height(56.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = AdegoTheme.colors.main500
+                    ),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text(
+                        text = "입장",
+                        style = AdegoTheme.typography.titleSmall,
+                        color = AdegoTheme.colors.onMain500
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // 안내 문구
+            Text(
+                text = "모임이 종료될 때까지 백그라운드에서도\n위치정보를 공유합니다.",
+                style = AdegoTheme.typography.bodySmall,
+                color = AdegoTheme.colors.line500
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+private fun HomeScreenPreview() {
+    AdegoTheme {
+        HomeScreen(
+            onNavigateToCreate = {},
+            onNavigateToSettings = {},
+            onJoinWithCode = {},
         )
     }
 }

--- a/feature/home/src/main/java/com/teammanduk/adego/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/teammanduk/adego/feature/home/navigation/HomeNavigation.kt
@@ -13,8 +13,16 @@ fun NavController.navigateToHome(
     navigate(Route.Home, navOptions)
 }
 
-fun NavGraphBuilder.homeNavGraph() {
+fun NavGraphBuilder.homeNavGraph(
+    onNavigateToCreate: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    onJoinWithCode: (String) -> Unit,
+) {
     composable<Route.Home> {
-        HomeRoute()
+        HomeRoute(
+            onNavigateToCreate = onNavigateToCreate,
+            onNavigateToSettings = onNavigateToSettings,
+            onJoinWithCode = onJoinWithCode,
+        )
     }
 }

--- a/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainNavHost.kt
+++ b/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainNavHost.kt
@@ -33,11 +33,12 @@ internal fun MainNavHost(
                 }
             )
             createNavGraph(
-                onNavigateBack = { navigator.navController.navigateUp() },
+                navController = navigator.navController,
+                onNavigateBack = navigator::navigateBack,
                 onNavigateToSelectPlace = navigator::navigateToSelectPlace,
                 onCreateMeeting = { place, hour, minute ->
                     /* TODO: 모임 생성 로직 구현 */
-                    navigator.navController.navigateUp()
+                    navigator.navigateToMap(hour, minute)
                 }
             )
             mapNavGraph()

--- a/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainNavHost.kt
+++ b/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainNavHost.kt
@@ -25,8 +25,21 @@ internal fun MainNavHost(
             navController = navigator.navController,
             startDestination = navigator.startDestination
         ) {
-            homeNavGraph()
-            createNavGraph()
+            homeNavGraph(
+                onNavigateToCreate = navigator::navigateToCreate,
+                onNavigateToSettings = { /* TODO: 설정 화면 구현 */ },
+                onJoinWithCode = { code ->
+                    /* TODO: 초대 코드로 입장 구현 */
+                }
+            )
+            createNavGraph(
+                onNavigateBack = { navigator.navController.navigateUp() },
+                onNavigateToSelectPlace = navigator::navigateToSelectPlace,
+                onCreateMeeting = { place, hour, minute ->
+                    /* TODO: 모임 생성 로직 구현 */
+                    navigator.navController.navigateUp()
+                }
+            )
             mapNavGraph()
         }
     }

--- a/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainNavHost.kt
+++ b/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainNavHost.kt
@@ -29,7 +29,9 @@ internal fun MainNavHost(
                 onNavigateToCreate = navigator::navigateToCreate,
                 onNavigateToSettings = { /* TODO: 설정 화면 구현 */ },
                 onJoinWithCode = { code ->
-                    /* TODO: 초대 코드로 입장 구현 */
+                    // TODO: 초대 코드로 서버에서 모임 정보 조회 후 시간 정보 가져오기
+                    // 임시: 기본 시간(0시 0분)으로 Map 화면 이동
+                    navigator.navigateToMap(0, 0)
                 }
             )
             createNavGraph(

--- a/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/navigation/MainNavigator.kt
+++ b/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/navigation/MainNavigator.kt
@@ -26,6 +26,7 @@ internal class MainNavigator(
             launchSingleTop = true
         }
     }
+    
 
     fun navigateHome() {
         navController.navigateToHome(navOptions)
@@ -36,11 +37,15 @@ internal class MainNavigator(
     }
 
     fun navigateToSelectPlace() {
-        navController.navigateToSelectPlace(navOptions)
+        navController.navigateToSelectPlace()
     }
 
-    fun navigateToMap() {
-        navController.navigateToMap(navOptions)
+    fun navigateToMap(hour: Int, minute: Int) {
+        navController.navigateToMap(hour, minute, navOptions)
+    }
+
+    fun navigateBack() {
+        navController.navigateUp()
     }
 }
 

--- a/feature/map/src/main/java/com/teammanduk/adego/feature/map/MapScreen.kt
+++ b/feature/map/src/main/java/com/teammanduk/adego/feature/map/MapScreen.kt
@@ -1,26 +1,727 @@
 package com.teammanduk.adego.feature.map
 
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
+import kotlinx.coroutines.launch
+import kotlin.math.atan2
+
+// 참가자 데이터 클래스
+private data class Participant(
+    val name: String,
+    val distanceInMeters: Int,
+    val status: String,
+    val color: Color
+)
 
 @Composable
-internal fun MapRoute() {
-    MapScreen()
+internal fun MapRoute(
+    meetingTime: String = "00시 00분",
+) {
+    MapScreen(
+        meetingTime = meetingTime
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun MapScreen(
+    meetingTime: String
+) {
+    // 임시 참가자 데이터
+    val participants = remember {
+        listOf(
+            Participant("홍길동", 0, "잠시 후 도착", Color(0xFFE53935)),
+            Participant("김철수", 300, "도착중", Color(0xFF5C6BC0)),
+            Participant("이영희", 500, "도착중", Color(0xFF43A047)),
+            Participant("박민수", 800, "도착중", Color(0xFFD81B60)),
+            Participant("최영수", 1200, "도착중", Color(0xFF00ACC1))
+        )
+    }
+
+    val pagerState = rememberPagerState(pageCount = { participants.size })
+    val coroutineScope = rememberCoroutineScope()
+    var showInviteDialog by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+    ) {
+        // 전체 화면 지도
+        MapPlaceholder(modifier = Modifier.fillMaxSize())
+
+        // 상단 영역
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .background(
+                    color = Color.White,
+                    shape = RoundedCornerShape(
+                        topStart = 0.dp,
+                        topEnd = 0.dp,
+                        bottomStart = 40.dp,
+                        bottomEnd = 40.dp
+                    )
+                )
+                .padding(horizontal = 24.dp, vertical = 40.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // 시간 + 인원 + 초대 버튼
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "$meetingTime 모임 시작",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = AdegoTheme.colors.onBackground
+                )
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "모임인원: ${participants.size}명",
+                        style = AdegoTheme.typography.bodyLarge,
+                        color = AdegoTheme.colors.highlight500
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .clip(CircleShape)
+                            .background(AdegoTheme.colors.highlight500)
+                            .clickable { showInviteDialog = true },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = "초대하기",
+                            tint = Color.White,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+            }
+
+            // 참가자 아이콘 바
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = Color(0xFFD6E9F5),
+                        shape = RoundedCornerShape(32.dp)
+                    )
+                    .padding(horizontal = 12.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                participants.forEachIndexed { index, participant ->
+                    val isSelected = pagerState.currentPage == index
+                    val iconSize by animateDpAsState(
+                        targetValue = if (isSelected) 40.dp else 32.dp,
+                        animationSpec = spring(
+                            dampingRatio = 0.7f,
+                            stiffness = 200f
+                        ),
+                        label = "iconSize"
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(56.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        // 심장 박동 동심원 애니메이션 (선택된 경우만)
+                        if (isSelected) {
+                            val infiniteTransition = rememberInfiniteTransition(label = "pulse")
+                            val pulseScale by infiniteTransition.animateFloat(
+                                initialValue = 1f,
+                                targetValue = 1.4f,
+                                animationSpec = infiniteRepeatable(
+                                    animation = tween(1000)
+                                ),
+                                label = "pulseScale"
+                            )
+                            val pulseAlpha by infiniteTransition.animateFloat(
+                                initialValue = 0.6f,
+                                targetValue = 0f,
+                                animationSpec = infiniteRepeatable(
+                                    animation = tween(1000)
+                                ),
+                                label = "pulseAlpha"
+                            )
+
+                            Box(
+                                modifier = Modifier
+                                    .size(iconSize * pulseScale)
+                                    .clip(CircleShape)
+                                    .background(participant.color.copy(alpha = pulseAlpha))
+                            )
+                        }
+
+                        // 메인 아이콘
+                        Box(
+                            modifier = Modifier
+                                .size(iconSize)
+                                .clip(CircleShape)
+                                .background(participant.color),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Person,
+                                contentDescription = participant.name,
+                                tint = Color.White,
+                                modifier = Modifier.size(if (isSelected) 24.dp else 20.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // 하단 참가자 카드 (스와이프)
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .padding(bottom = 16.dp)
+        ) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxWidth(),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 32.dp),
+                pageSpacing = 16.dp
+            ) { page ->
+                ParticipantCard(
+                    participant = participants[page],
+                    currentPage = pagerState.currentPage,
+                    totalPages = participants.size,
+                    onPreviousClick = {
+                        coroutineScope.launch {
+                            if (pagerState.currentPage > 0) {
+                                pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                            }
+                        }
+                    },
+                    onNextClick = {
+                        coroutineScope.launch {
+                            if (pagerState.currentPage < participants.size - 1) {
+                                pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                            }
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+
+        // 지도 위 참가자 위치 마커들 (상단/하단 패딩으로 영역 제한)
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 200.dp, bottom = 240.dp)  // 상단 섹션과 하단 카드 영역 제외
+        ) {
+            val screenWidth = maxWidth
+            val screenHeight = maxHeight
+
+            participants.forEachIndexed { index, participant ->
+                // TODO: 실제 위치 데이터로 대체 필요
+                // 임시로 위치 표시 (일부는 화면 밖, 다양한 방향으로 분산)
+                val offsetX = when (participant.name) {
+                    "홍길동" -> screenWidth / 2  // 화면 내
+                    "김철수" -> screenWidth + 100.dp  // 화면 밖 (오른쪽)
+                    "이영희" -> screenWidth / 2  // 화면 밖 (아래)
+                    "박민수" -> -100.dp  // 화면 밖 (왼쪽)
+                    "최영수" -> screenWidth / 2  // 화면 밖 (위)
+                    else -> 150.dp
+                }
+                val offsetY = when (participant.name) {
+                    "홍길동" -> screenHeight / 2  // 화면 내
+                    "김철수" -> screenHeight / 2  // 화면 밖 (오른쪽)
+                    "이영희" -> screenHeight + 100.dp  // 화면 밖 (아래)
+                    "박민수" -> screenHeight / 2  // 화면 밖 (왼쪽)
+                    "최영수" -> -50.dp  // 화면 밖 (위)
+                    else -> screenHeight / 2
+                }
+
+                // 경계값 정의 (dp) - 이제 padding된 영역 내부 기준
+                val topBound = 0.dp
+                val bottomBound = screenHeight
+                val leftBound = 16.dp
+                val rightBound = screenWidth - 80.dp
+
+                val isSelected = pagerState.currentPage == index
+                val isOutOfBounds = offsetX < leftBound || offsetX > rightBound ||
+                        offsetY < topBound || offsetY > bottomBound
+
+                if (isOutOfBounds) {
+                    // 화면 밖 참가자 - 말풍선으로 표시
+                    // 실제 위치를 경계 내로 제한 (말풍선을 표시할 위치)
+                    val edgeX = offsetX.coerceIn(leftBound, rightBound)
+                    val edgeY = offsetY.coerceIn(topBound, bottomBound)
+
+                    // 말풍선 위치에서 실제 위치로의 방향 (꼬리 방향)
+                    val dx = (offsetX - edgeX).value
+                    val dy = (offsetY - edgeY).value
+                    val angle = atan2(dy, dx)
+
+                    Box(
+                        modifier = Modifier
+                            .padding(start = edgeX, top = edgeY)
+                            .size(48.dp)
+                            .align(Alignment.TopStart)
+                            .drawBehind {
+                                // 원형 배경
+                                drawCircle(
+                                    color = participant.color,
+                                    radius = 20.dp.toPx(),
+                                    center = center
+                                )
+
+                                // 말풍선 꼬리 (삼각형)
+                                val tailSize = 10.dp.toPx()
+                                val circleRadius = 20.dp.toPx()
+
+                                // 각도에 따른 꼬리 시작점 계산
+                                val tailBaseX = center.x + kotlin.math.cos(angle) * circleRadius
+                                val tailBaseY = center.y + kotlin.math.sin(angle) * circleRadius
+                                val tailTipX = tailBaseX + kotlin.math.cos(angle) * tailSize
+                                val tailTipY = tailBaseY + kotlin.math.sin(angle) * tailSize
+
+                                // 삼각형 양 옆 점 계산
+                                val perpAngle1 = angle + Math.PI / 2
+                                val perpAngle2 = angle - Math.PI / 2
+                                val baseOffset = 6.dp.toPx()
+
+                                val point1X = tailBaseX + kotlin.math.cos(perpAngle1) * baseOffset
+                                val point1Y = tailBaseY + kotlin.math.sin(perpAngle1) * baseOffset
+                                val point2X = tailBaseX + kotlin.math.cos(perpAngle2) * baseOffset
+                                val point2Y = tailBaseY + kotlin.math.sin(perpAngle2) * baseOffset
+
+                                val tailPath = Path().apply {
+                                    moveTo(point1X.toFloat(), point1Y.toFloat())
+                                    lineTo(tailTipX.toFloat(), tailTipY.toFloat())
+                                    lineTo(point2X.toFloat(), point2Y.toFloat())
+                                    close()
+                                }
+                                drawPath(tailPath, participant.color)
+
+                                // 흰색 테두리 - 원
+                                drawCircle(
+                                    color = androidx.compose.ui.graphics.Color.White,
+                                    radius = 20.dp.toPx(),
+                                    center = center,
+                                    style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2.dp.toPx())
+                                )
+
+                                // 흰색 테두리 - 꼬리
+                                drawPath(
+                                    tailPath,
+                                    color = androidx.compose.ui.graphics.Color.White,
+                                    style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2.dp.toPx())
+                                )
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Person,
+                            contentDescription = participant.name,
+                            tint = Color.White,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                } else {
+                    // 화면 내 참가자 - 일반 마커
+                    Box(
+                        modifier = Modifier
+                            .padding(start = offsetX, top = offsetY)
+                            .size(56.dp)
+                            .align(Alignment.TopStart),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        // 심장 박동 동심원 애니메이션 (선택된 경우만)
+                        if (isSelected) {
+                            val infiniteTransition = rememberInfiniteTransition(label = "mapPulse")
+                            val pulseScale by infiniteTransition.animateFloat(
+                                initialValue = 1f,
+                                targetValue = 1.5f,
+                                animationSpec = infiniteRepeatable(
+                                    animation = tween(1000)
+                                ),
+                                label = "mapPulseScale"
+                            )
+                            val pulseAlpha by infiniteTransition.animateFloat(
+                                initialValue = 0.6f,
+                                targetValue = 0f,
+                                animationSpec = infiniteRepeatable(
+                                    animation = tween(1000)
+                                ),
+                                label = "mapPulseAlpha"
+                            )
+
+                            Box(
+                                modifier = Modifier
+                                    .size(40.dp * pulseScale)
+                                    .clip(CircleShape)
+                                    .background(participant.color.copy(alpha = pulseAlpha))
+                            )
+                        }
+
+                        // 메인 마커
+                        Box(
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .background(participant.color),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Person,
+                                contentDescription = participant.name,
+                                tint = Color.White,
+                                modifier = Modifier.size(28.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // 초대 다이얼로그
+    if (showInviteDialog) {
+        InviteDialog(
+            inviteCode = "ABC123",
+            onDismiss = { showInviteDialog = false }
+        )
+    }
 }
 
 @Composable
-private fun MapScreen() {
+private fun MapPlaceholder(
+    modifier: Modifier = Modifier
+) {
     Box(
-        modifier = Modifier
-            .fillMaxSize(),
+        modifier = modifier
+            .background(Color(0xFFE0E0E0)),
         contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = "실시간 지도"
+        Icon(
+            imageVector = Icons.Default.LocationOn,
+            contentDescription = "지도 영역",
+            tint = Color(0xFF757575),
+            modifier = Modifier.size(64.dp)
+        )
+    }
+}
+
+@Composable
+private fun ParticipantCard(
+    participant: Participant,
+    currentPage: Int,
+    totalPages: Int,
+    onPreviousClick: () -> Unit,
+    onNextClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .background(
+                color = Color.White,
+                shape = RoundedCornerShape(24.dp)
+            )
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // 프로필 + 정보
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // 프로필 아이콘
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(CircleShape)
+                    .background(participant.color),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Person,
+                    contentDescription = "프로필",
+                    tint = Color.White,
+                    modifier = Modifier.size(48.dp)
+                )
+            }
+
+            // 이름 + 상태
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = participant.name,
+                    style = AdegoTheme.typography.headlineLarge,
+                    color = AdegoTheme.colors.onBackground
+                )
+
+                Text(
+                    text = participant.status,
+                    style = AdegoTheme.typography.bodyLarge,
+                    color = Color(0xFF9E9E9E)
+                )
+            }
+        }
+
+        // 화살표 + 인디케이터
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // 이전 버튼
+            IconButton(
+                onClick = onPreviousClick,
+                enabled = currentPage > 0
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                    contentDescription = "이전",
+                    tint = if (currentPage > 0) AdegoTheme.colors.main500 else Color(0xFFE0E0E0),
+                    modifier = Modifier.size(32.dp)
+                )
+            }
+
+            // 페이지 인디케이터
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                repeat(totalPages) { index ->
+                    Box(
+                        modifier = Modifier
+                            .size(8.dp)
+                            .clip(CircleShape)
+                            .background(
+                                if (index == currentPage) AdegoTheme.colors.main500
+                                else Color(0xFFE0E0E0)
+                            )
+                    )
+                }
+            }
+
+            // 다음 버튼
+            IconButton(
+                onClick = onNextClick,
+                enabled = currentPage < totalPages - 1
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = "다음",
+                    tint = if (currentPage < totalPages - 1) AdegoTheme.colors.main500 else Color(
+                        0xFFE0E0E0
+                    ),
+                    modifier = Modifier.size(32.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InviteDialog(
+    inviteCode: String,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .background(Color.White, RoundedCornerShape(16.dp))
+                .padding(24.dp)
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "모임 초대",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = AdegoTheme.colors.onBackground
+                )
+
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "닫기",
+                        tint = AdegoTheme.colors.onBackground
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 초대 코드 표시
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "초대 코드",
+                    style = AdegoTheme.typography.bodyLarge,
+                    color = AdegoTheme.colors.onBackground
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 2.dp,
+                            color = AdegoTheme.colors.main500,
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                        .padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = inviteCode,
+                        style = AdegoTheme.typography.headlineLarge,
+                        color = AdegoTheme.colors.main500,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 코드 복사 버튼
+            Button(
+                onClick = {
+                    // TODO: 클립보드에 코드 복사
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = AdegoTheme.colors.main500
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Create,
+                    contentDescription = null,
+                    tint = Color.White
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "코드 복사",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = Color.White
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // SNS 공유 버튼
+            OutlinedButton(
+                onClick = {
+                    // TODO: SNS 공유 기능
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = AdegoTheme.colors.main500
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Share,
+                    contentDescription = null,
+                    tint = AdegoTheme.colors.main500
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "SNS 공유",
+                    style = AdegoTheme.typography.titleLarge,
+                    color = AdegoTheme.colors.main500
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+private fun MapScreenPreview() {
+    AdegoTheme {
+        MapScreen(
+            meetingTime = "14시 30분"
         )
     }
 }

--- a/feature/map/src/main/java/com/teammanduk/adego/feature/map/navigation/MapNavigation.kt
+++ b/feature/map/src/main/java/com/teammanduk/adego/feature/map/navigation/MapNavigation.kt
@@ -4,17 +4,25 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.teammanduk.adego.core.navigation.Route
 import com.teammanduk.adego.feature.map.MapRoute
 
 fun NavController.navigateToMap(
+    hour: Int,
+    minute: Int,
     navOptions: NavOptions? = null
 ) {
-    navigate(Route.Map, navOptions)
+    navigate(Route.Map(hour = hour, minute = minute), navOptions)
 }
 
 fun NavGraphBuilder.mapNavGraph() {
-    composable<Route.Map> {
-        MapRoute()
+    composable<Route.Map> { backStackEntry ->
+        val route = backStackEntry.toRoute<Route.Map>()
+        val meetingTime = String.format("%02d시 %02d분", route.hour, route.minute)
+
+        MapRoute(
+            meetingTime = meetingTime
+        )
     }
 }


### PR DESCRIPTION
  ## Summary
  - 전체 화면 와이어프레임 UI 구현 완료
  - 디자인 시스템 구축 (Color, Typography, Theme)
  - Home, Create, SelectPlace, Map 화면 UI 구현
  - 화면 간 네비게이션 연결
  - 커스텀 DatePicker, TimePicker 컴포넌트 추가

  ## 주요 변경사항

  ### 디자인 시스템
  - AdegoTheme 컬러 시스템 구축 (main500, background, line500 등)
  - Typography 시스템 구축 (headlineLarge, titleLarge, bodyLarge 등)
  - AdegoDatePicker, AdegoTimePicker 컴포넌트 추가

  ### 화면 구현
  - **Home**: 새 모임 만들기, 초대코드 입력
  - **Create**: 장소/날짜/시간 선택, 모임 생성
  - **SelectPlace**: 장소 선택 (지도 placeholder)
  - **Map**: 참가자 위치 표시, 도착 예정 시간, 초대 다이얼로그

  ### 네비게이션 흐름
  1. Home → Create → SelectPlace → Create → Map
  2. Home → 초대코드 입력 → Map

  ## Test plan
  - [ ] 앱 실행 시 Home 화면 정상 표시
  - [ ] "새 모임 만들기" 버튼으로 Create 화면 이동
  - [ ] Create 화면에서 장소/날짜/시간 선택 가능
  - [ ] DatePicker, TimePicker 정상 동작
  - [ ] "모임 생성하기" 버튼으로 Map 화면 이동
  - [ ] Home에서 초대코드 입력 후 Map 화면 이동
  - [ ] Map 화면에서 참가자 목록 표시
  - [ ] 초대 다이얼로그 정상 동작
  - [ ] 뒤로가기 네비게이션 정상 동작
