### PR TITLE
feat: 지도 화면 MVI 아키텍처 패턴 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ import java.io.FileInputStream
 plugins {
     alias(libs.plugins.adego.android.application)
     alias(libs.plugins.adego.android.compose)
+    alias(libs.plugins.google.services)
 }
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,13 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
+    <!-- 백그라운드 위치 추적 (Android 10+) -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
+    <!-- Foreground Service (위치 추적 서비스) -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+
     <application
         android:name=".AdegoApplication"
         android:allowBackup="true"

--- a/app/src/main/kotlin/com/teammanduk/adego/AdegoApplication.kt
+++ b/app/src/main/kotlin/com/teammanduk/adego/AdegoApplication.kt
@@ -1,11 +1,12 @@
 package com.teammanduk.adego
 
 import android.app.Application
+import android.util.Log
 import com.google.android.libraries.places.api.Places
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class AdegoApplication: Application() {
+class AdegoApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
@@ -14,5 +15,6 @@ class AdegoApplication: Application() {
         if (!Places.isInitialized()) {
             Places.initialize(applicationContext, BuildConfig.MAPS_API_KEY)
         }
+        Log.d("AdegoApp", "앱 초기화 완료")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,5 @@ plugins {
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.google.services) apply false
 }

--- a/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/datasource/LocationDataSource.kt
+++ b/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/datasource/LocationDataSource.kt
@@ -1,0 +1,26 @@
+package com.teammanduk.adego.core.data_api.datasource
+
+import com.teammanduk.adego.core.data_api.model.ParticipantLocationDto
+import kotlinx.coroutines.flow.Flow
+
+interface LocationDataSource {
+    /**
+     * 현재 위치 가져오기
+     */
+    suspend fun getCurrentLocation(): Result<ParticipantLocationDto>
+
+    /**
+     * 위치 업데이트 Flow
+     */
+    fun getLocationUpdates(): Flow<ParticipantLocationDto>
+
+    /**
+     * 위치 추적 시작
+     */
+    suspend fun startTracking(): Result<Unit>
+
+    /**
+     * 위치 추적 중지
+     */
+    suspend fun stopTracking(): Result<Unit>
+}

--- a/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/datasource/RoomDataSource.kt
+++ b/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/datasource/RoomDataSource.kt
@@ -1,0 +1,68 @@
+package com.teammanduk.adego.core.data_api.datasource
+
+import com.teammanduk.adego.core.data_api.model.ParticipantDto
+import com.teammanduk.adego.core.data_api.model.RoomDto
+import kotlinx.coroutines.flow.Flow
+
+interface RoomDataSource {
+    /**
+     * 방 생성
+     */
+    suspend fun createRoom(roomDto: RoomDto): Result<Unit>
+
+    /**
+     * 방 정보 조회
+     */
+    suspend fun getRoom(roomId: String): Result<RoomDto?>
+
+    /**
+     * 방 정보 실시간 구독
+     */
+    fun observeRoom(roomId: String): Flow<RoomDto?>
+
+    /**
+     * 참여자 추가
+     */
+    suspend fun addParticipant(roomId: String, participantDto: ParticipantDto): Result<Unit>
+
+    /**
+     * 참여자 목록 실시간 구독
+     */
+    fun observeParticipants(roomId: String): Flow<List<ParticipantDto>>
+
+    /**
+     * 참여자 위치 업데이트
+     */
+    suspend fun updateParticipantLocation(
+        roomId: String,
+        userId: String,
+        latitude: Double,
+        longitude: Double,
+        accuracy: Float,
+        timestamp: Long
+    ): Result<Unit>
+
+    /**
+     * 참여자 경로 업데이트
+     */
+    suspend fun updateParticipantRoute(
+        roomId: String,
+        userId: String,
+        eta: String,
+        distance: String,
+        polyline: String,
+        durationInSeconds: Int,
+        distanceInMeters: Int,
+        timestamp: Long
+    ): Result<Unit>
+
+    /**
+     * 참여자 제거
+     */
+    suspend fun removeParticipant(roomId: String, userId: String): Result<Unit>
+
+    /**
+     * 고유 코드 생성 (6자리 영숫자)
+     */
+    suspend fun generateUniqueRoomId(): String
+}

--- a/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/model/ParticipantDto.kt
+++ b/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/model/ParticipantDto.kt
@@ -1,0 +1,25 @@
+package com.teammanduk.adego.core.data_api.model
+
+data class ParticipantDto(
+    val userId: String = "",
+    val name: String = "",
+    val profileColor: String = "",
+    val location: ParticipantLocationDto? = null,
+    val route: ParticipantRouteDto? = null
+)
+
+data class ParticipantLocationDto(
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
+    val updatedAt: Long = 0L,
+    val accuracy: Float = 0f
+)
+
+data class ParticipantRouteDto(
+    val eta: String = "",
+    val distance: String = "",
+    val polyline: String = "",
+    val durationInSeconds: Int = 0,
+    val distanceInMeters: Int = 0,
+    val updatedAt: Long = 0L
+)

--- a/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/model/PlaceDto.kt
+++ b/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/model/PlaceDto.kt
@@ -1,8 +1,8 @@
 package com.teammanduk.adego.core.data_api.model
 
 data class PlaceDto(
-    val name: String,
-    val address: String,
-    val latitude: Double,
-    val longitude: Double
+    val name: String = "",
+    val address: String = "",
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0
 )

--- a/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/model/RoomDto.kt
+++ b/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/model/RoomDto.kt
@@ -1,0 +1,10 @@
+package com.teammanduk.adego.core.data_api.model
+
+data class RoomDto(
+    val roomId: String = "",
+    val roomName: String = "",
+    val destination: PlaceDto = PlaceDto(),
+    val dateTime: String = "",
+    val createdBy: String = "",
+    val createdAt: Long = 0L
+)

--- a/core/data/src/main/kotlin/com/teammanduk/adego/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/teammanduk/adego/core/data/di/DataModule.kt
@@ -1,7 +1,11 @@
 package com.teammanduk.adego.core.data.di
 
+import com.teammanduk.adego.core.data.repository.LocationRepositoryImpl
 import com.teammanduk.adego.core.data.repository.PlaceRepositoryImpl
+import com.teammanduk.adego.core.data.repository.RoomRepositoryImpl
+import com.teammanduk.adego.core.domain.repository.LocationRepository
 import com.teammanduk.adego.core.domain.repository.PlaceRepository
+import com.teammanduk.adego.core.domain.repository.RoomRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -16,4 +20,16 @@ abstract class DataModule {
     abstract fun bindPlaceRepository(
         placeRepositoryImpl: PlaceRepositoryImpl
     ): PlaceRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindRoomRepository(
+        roomRepositoryImpl: RoomRepositoryImpl
+    ): RoomRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindLocationRepository(
+        locationRepositoryImpl: LocationRepositoryImpl
+    ): LocationRepository
 }

--- a/core/data/src/main/kotlin/com/teammanduk/adego/core/data/mapper/RoomMapper.kt
+++ b/core/data/src/main/kotlin/com/teammanduk/adego/core/data/mapper/RoomMapper.kt
@@ -1,0 +1,98 @@
+package com.teammanduk.adego.core.data.mapper
+
+import com.teammanduk.adego.core.data_api.model.ParticipantDto
+import com.teammanduk.adego.core.data_api.model.ParticipantLocationDto
+import com.teammanduk.adego.core.data_api.model.ParticipantRouteDto
+import com.teammanduk.adego.core.data_api.model.PlaceDto
+import com.teammanduk.adego.core.data_api.model.RoomDto
+import com.teammanduk.adego.core.model.Participant
+import com.teammanduk.adego.core.model.ParticipantLocation
+import com.teammanduk.adego.core.model.ParticipantRoute
+import com.teammanduk.adego.core.model.Place
+import com.teammanduk.adego.core.model.Room
+
+// Room
+fun RoomDto.toModel(): Room {
+    return Room(
+        roomId = roomId,
+        roomName = roomName,
+        destination = destination.toModel(),
+        dateTime = dateTime,
+        createdBy = createdBy,
+        createdAt = createdAt
+    )
+}
+
+fun Room.toDto(): RoomDto {
+    return RoomDto(
+        roomId = roomId,
+        roomName = roomName,
+        destination = destination.toDto(),
+        dateTime = dateTime,
+        createdBy = createdBy,
+        createdAt = createdAt
+    )
+}
+
+// Participant
+fun ParticipantDto.toModel(): Participant {
+    return Participant(
+        userId = userId,
+        name = name,
+        profileColor = profileColor,
+        location = location?.toModel(),
+        route = route?.toModel()
+    )
+}
+
+fun Participant.toDto(): ParticipantDto {
+    return ParticipantDto(
+        userId = userId,
+        name = name,
+        profileColor = profileColor,
+        location = location?.toDto(),
+        route = route?.toDto()
+    )
+}
+
+// ParticipantLocation
+fun ParticipantLocationDto.toModel(): ParticipantLocation {
+    return ParticipantLocation(
+        latitude = latitude,
+        longitude = longitude,
+        updatedAt = updatedAt,
+        accuracy = accuracy
+    )
+}
+
+fun ParticipantLocation.toDto(): ParticipantLocationDto {
+    return ParticipantLocationDto(
+        latitude = latitude,
+        longitude = longitude,
+        updatedAt = updatedAt,
+        accuracy = accuracy
+    )
+}
+
+// ParticipantRoute
+fun ParticipantRouteDto.toModel(): ParticipantRoute {
+    return ParticipantRoute(
+        eta = eta,
+        distance = distance,
+        polyline = polyline,
+        durationInSeconds = durationInSeconds,
+        distanceInMeters = distanceInMeters,
+        updatedAt = updatedAt
+    )
+}
+
+fun ParticipantRoute.toDto(): ParticipantRouteDto {
+    return ParticipantRouteDto(
+        eta = eta,
+        distance = distance,
+        polyline = polyline,
+        durationInSeconds = durationInSeconds,
+        distanceInMeters = distanceInMeters,
+        updatedAt = updatedAt
+    )
+}

--- a/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/LocationRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/LocationRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package com.teammanduk.adego.core.data.repository
+
+import com.teammanduk.adego.core.data.mapper.toModel
+import com.teammanduk.adego.core.data_api.datasource.LocationDataSource
+import com.teammanduk.adego.core.domain.repository.LocationRepository
+import com.teammanduk.adego.core.model.ParticipantLocation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LocationRepositoryImpl @Inject constructor(
+    private val locationDataSource: LocationDataSource
+) : LocationRepository {
+
+    override suspend fun getCurrentLocation(): Result<ParticipantLocation> {
+        return try {
+            val locationDto = locationDataSource.getCurrentLocation().getOrThrow()
+            Result.success(locationDto.toModel())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override fun observeLocationUpdates(): Flow<ParticipantLocation> {
+        return locationDataSource.getLocationUpdates()
+            .map { it.toModel() }
+    }
+
+    override suspend fun startLocationTracking(): Result<Unit> {
+        return locationDataSource.startTracking()
+    }
+
+    override suspend fun stopLocationTracking(): Result<Unit> {
+        return locationDataSource.stopTracking()
+    }
+}

--- a/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/RoomRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/RoomRepositoryImpl.kt
@@ -147,10 +147,55 @@ class RoomRepositoryImpl @Inject constructor(
     }
 
     override fun observeParticipants(roomId: String): Flow<List<Participant>> {
-        return roomDataSource.observeParticipants(roomId)
-            .map { participants ->
-                participants.map { it.toModel() }
+        // Room 정보와 참가자 정보를 combine하여 거리 계산
+        return kotlinx.coroutines.flow.combine(
+            roomDataSource.observeRoom(roomId),
+            roomDataSource.observeParticipants(roomId)
+        ) { roomDto, participantDtos ->
+            val destination = roomDto?.destination
+
+            participantDtos.map { participantDto ->
+                val participant = participantDto.toModel()
+
+                // 목적지와 참가자 위치가 모두 있으면 거리 계산
+                val location = participant.location
+                val distance = if (destination != null && location != null) {
+                    calculateHaversineDistance(
+                        lat1 = location.latitude,
+                        lon1 = location.longitude,
+                        lat2 = destination.latitude,
+                        lon2 = destination.longitude
+                    )
+                } else {
+                    null
+                }
+
+                participant.copy(distanceToDestination = distance)
             }
+        }
+    }
+
+    /**
+     * Haversine 공식을 사용한 두 지점 간 직선 거리 계산 (미터)
+     */
+    private fun calculateHaversineDistance(
+        lat1: Double,
+        lon1: Double,
+        lat2: Double,
+        lon2: Double
+    ): Int {
+        val earthRadiusMeters = 6371000.0 // 지구 반지름 (미터)
+
+        val dLat = Math.toRadians(lat2 - lat1)
+        val dLon = Math.toRadians(lon2 - lon1)
+
+        val a = kotlin.math.sin(dLat / 2) * kotlin.math.sin(dLat / 2) +
+                kotlin.math.cos(Math.toRadians(lat1)) * kotlin.math.cos(Math.toRadians(lat2)) *
+                kotlin.math.sin(dLon / 2) * kotlin.math.sin(dLon / 2)
+
+        val c = 2 * kotlin.math.atan2(kotlin.math.sqrt(a), kotlin.math.sqrt(1 - a))
+
+        return (earthRadiusMeters * c).toInt()
     }
 
     override suspend fun updateMyLocation(

--- a/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/RoomRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/RoomRepositoryImpl.kt
@@ -1,0 +1,184 @@
+package com.teammanduk.adego.core.data.repository
+
+import android.util.Log
+import com.teammanduk.adego.core.data.mapper.toDto
+import com.teammanduk.adego.core.data.mapper.toModel
+import com.teammanduk.adego.core.data_api.datasource.RoomDataSource
+import com.teammanduk.adego.core.data_api.model.ParticipantDto
+import com.teammanduk.adego.core.domain.repository.RoomRepository
+import com.teammanduk.adego.core.model.Participant
+import com.teammanduk.adego.core.model.ParticipantLocation
+import com.teammanduk.adego.core.model.ParticipantRoute
+import com.teammanduk.adego.core.model.Place
+import com.teammanduk.adego.core.model.Room
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RoomRepositoryImpl @Inject constructor(
+    private val roomDataSource: RoomDataSource
+) : RoomRepository {
+
+    /**
+     * userId를 기반으로 고유한 색상을 생성
+     * 같은 userId는 항상 같은 색상을 반환
+     */
+    private fun generateColorFromUserId(userId: String): String {
+        // userId의 해시코드 생성
+        val hash = userId.hashCode()
+
+        // HSV 색상 공간 사용 (Hue, Saturation, Value)
+        // Hue: 0-360 범위로 매핑하여 다양한 색상 생성
+        val hue = (hash.toFloat().rem(360f) + 360f).rem(360f)
+
+        // 채도와 명도를 고정하여 선명하고 보기 좋은 색상 생성
+        val saturation = 0.7f  // 70% 채도
+        val value = 0.9f       // 90% 명도
+
+        // HSV를 RGB로 변환
+        val rgb = android.graphics.Color.HSVToColor(floatArrayOf(hue, saturation, value))
+
+        // #RRGGBB 형식으로 반환
+        return String.format("#%06X", 0xFFFFFF and rgb)
+    }
+
+    override suspend fun createRoom(
+        roomName: String,
+        destination: Place,
+        dateTime: String,
+        userId: String,
+        userName: String
+    ): Result<String> {
+        return try {
+            Log.d(TAG, "[Repository] 방 생성 시작")
+
+            // 고유 코드 생성
+            val roomId = roomDataSource.generateUniqueRoomId()
+            Log.d(TAG, "[Repository] 고유 roomId 생성: $roomId")
+
+            // Room 생성
+            val roomDto = Room(
+                roomId = roomId,
+                roomName = roomName,
+                destination = destination,
+                dateTime = dateTime,
+                createdBy = userId,
+                createdAt = System.currentTimeMillis()
+            ).toDto()
+
+            Log.d(TAG, "[Repository] Firebase에 Room 데이터 저장 중...")
+            roomDataSource.createRoom(roomDto).getOrThrow()
+            Log.d(TAG, "[Repository] Room 데이터 저장 완료")
+
+            // 생성자를 첫 번째 참여자로 추가
+            val profileColor = generateColorFromUserId(userId)
+            Log.d(TAG, "[Repository] userId=$userId -> profileColor=$profileColor")
+
+            val creatorParticipant = ParticipantDto(
+                userId = userId,
+                name = userName,
+                profileColor = profileColor,
+                location = null,
+                route = null
+            )
+
+            Log.d(TAG, "[Repository] 생성자를 참여자로 추가 중...")
+            roomDataSource.addParticipant(roomId, creatorParticipant).getOrThrow()
+            Log.d(TAG, "[Repository] 참여자 추가 완료")
+
+            Log.d(TAG, "[Repository] 방 생성 완료! roomId=$roomId")
+            Result.success(roomId)
+        } catch (e: Exception) {
+            Log.e(TAG, "[Repository] 방 생성 실패", e)
+            Result.failure(e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "AdegoRoom"
+    }
+
+    override suspend fun joinRoom(
+        roomId: String,
+        userId: String,
+        userName: String
+    ): Result<Unit> {
+        return try {
+            // 방 존재 여부 확인
+            val room = roomDataSource.getRoom(roomId).getOrNull()
+                ?: return Result.failure(Exception("Room not found"))
+
+            // 참여자 추가
+            val participant = ParticipantDto(
+                userId = userId,
+                name = userName,
+                profileColor = generateColorFromUserId(userId),
+                location = null,
+                route = null
+            )
+
+            roomDataSource.addParticipant(roomId, participant)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getRoomInfo(roomId: String): Result<Room?> {
+        return try {
+            val roomDto = roomDataSource.getRoom(roomId).getOrNull()
+            Result.success(roomDto?.toModel())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override fun observeRoom(roomId: String): Flow<Room?> {
+        return roomDataSource.observeRoom(roomId)
+            .map { it?.toModel() }
+    }
+
+    override fun observeParticipants(roomId: String): Flow<List<Participant>> {
+        return roomDataSource.observeParticipants(roomId)
+            .map { participants ->
+                participants.map { it.toModel() }
+            }
+    }
+
+    override suspend fun updateMyLocation(
+        roomId: String,
+        userId: String,
+        location: ParticipantLocation
+    ): Result<Unit> {
+        return roomDataSource.updateParticipantLocation(
+            roomId = roomId,
+            userId = userId,
+            latitude = location.latitude,
+            longitude = location.longitude,
+            accuracy = location.accuracy,
+            timestamp = location.updatedAt
+        )
+    }
+
+    override suspend fun updateMyRoute(
+        roomId: String,
+        userId: String,
+        route: ParticipantRoute
+    ): Result<Unit> {
+        return roomDataSource.updateParticipantRoute(
+            roomId = roomId,
+            userId = userId,
+            eta = route.eta,
+            distance = route.distance,
+            polyline = route.polyline,
+            durationInSeconds = route.durationInSeconds,
+            distanceInMeters = route.distanceInMeters,
+            timestamp = route.updatedAt
+        )
+    }
+
+    override suspend fun leaveRoom(roomId: String, userId: String): Result<Unit> {
+        return roomDataSource.removeParticipant(roomId, userId)
+    }
+}

--- a/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/RoomRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/RoomRepositoryImpl.kt
@@ -106,21 +106,28 @@ class RoomRepositoryImpl @Inject constructor(
         userName: String
     ): Result<Unit> {
         return try {
+            Log.d(TAG, "[Repository] 방 참여 시작 - roomId: $roomId, userId: $userId")
+
             // 방 존재 여부 확인
             val room = roomDataSource.getRoom(roomId).getOrNull()
                 ?: return Result.failure(Exception("Room not found"))
+
+            // 참여자 색상 생성
+            val profileColor = generateColorFromUserId(userId)
+            Log.d(TAG, "[Repository] joinRoom - userId=$userId -> profileColor=$profileColor")
 
             // 참여자 추가
             val participant = ParticipantDto(
                 userId = userId,
                 name = userName,
-                profileColor = generateColorFromUserId(userId),
+                profileColor = profileColor,
                 location = null,
                 route = null
             )
 
             roomDataSource.addParticipant(roomId, participant)
         } catch (e: Exception) {
+            Log.e(TAG, "[Repository] 방 참여 실패", e)
             Result.failure(e)
         }
     }

--- a/core/domain/src/main/kotlin/com/teammanduk/adego/core/domain/repository/LocationRepository.kt
+++ b/core/domain/src/main/kotlin/com/teammanduk/adego/core/domain/repository/LocationRepository.kt
@@ -1,0 +1,26 @@
+package com.teammanduk.adego.core.domain.repository
+
+import com.teammanduk.adego.core.model.ParticipantLocation
+import kotlinx.coroutines.flow.Flow
+
+interface LocationRepository {
+    /**
+     * 현재 위치 가져오기 (1회)
+     */
+    suspend fun getCurrentLocation(): Result<ParticipantLocation>
+
+    /**
+     * 위치 업데이트 구독 (실시간)
+     */
+    fun observeLocationUpdates(): Flow<ParticipantLocation>
+
+    /**
+     * 위치 추적 시작
+     */
+    suspend fun startLocationTracking(): Result<Unit>
+
+    /**
+     * 위치 추적 중지
+     */
+    suspend fun stopLocationTracking(): Result<Unit>
+}

--- a/core/domain/src/main/kotlin/com/teammanduk/adego/core/domain/repository/RoomRepository.kt
+++ b/core/domain/src/main/kotlin/com/teammanduk/adego/core/domain/repository/RoomRepository.kt
@@ -1,0 +1,67 @@
+package com.teammanduk.adego.core.domain.repository
+
+import com.teammanduk.adego.core.model.Participant
+import com.teammanduk.adego.core.model.ParticipantLocation
+import com.teammanduk.adego.core.model.ParticipantRoute
+import com.teammanduk.adego.core.model.Room
+import kotlinx.coroutines.flow.Flow
+
+interface RoomRepository {
+    /**
+     * 방 생성 (고유 코드 자동 생성)
+     */
+    suspend fun createRoom(
+        roomName: String,
+        destination: com.teammanduk.adego.core.model.Place,
+        dateTime: String,
+        userId: String,
+        userName: String
+    ): Result<String> // roomId 반환
+
+    /**
+     * 초대 코드로 방 참여
+     */
+    suspend fun joinRoom(
+        roomId: String,
+        userId: String,
+        userName: String
+    ): Result<Unit>
+
+    /**
+     * 방 정보 조회 (1회)
+     */
+    suspend fun getRoomInfo(roomId: String): Result<Room?>
+
+    /**
+     * 방 정보 실시간 구독
+     */
+    fun observeRoom(roomId: String): Flow<Room?>
+
+    /**
+     * 참여자 목록 실시간 구독
+     */
+    fun observeParticipants(roomId: String): Flow<List<Participant>>
+
+    /**
+     * 내 위치 업데이트
+     */
+    suspend fun updateMyLocation(
+        roomId: String,
+        userId: String,
+        location: ParticipantLocation
+    ): Result<Unit>
+
+    /**
+     * 내 경로 업데이트
+     */
+    suspend fun updateMyRoute(
+        roomId: String,
+        userId: String,
+        route: ParticipantRoute
+    ): Result<Unit>
+
+    /**
+     * 방 나가기
+     */
+    suspend fun leaveRoom(roomId: String, userId: String): Result<Unit>
+}

--- a/core/model/src/main/kotlin/com/teammanduk/adego/core/model/Participant.kt
+++ b/core/model/src/main/kotlin/com/teammanduk/adego/core/model/Participant.kt
@@ -1,0 +1,12 @@
+package com.teammanduk.adego.core.model
+
+/**
+ * 참여자 정보 (동적 데이터 - 위치/경로 실시간 변경)
+ */
+data class Participant(
+    val userId: String,
+    val name: String,
+    val profileColor: String, // 색상 hex 코드 (예: "#E53935")
+    val location: ParticipantLocation? = null,
+    val route: ParticipantRoute? = null
+)

--- a/core/model/src/main/kotlin/com/teammanduk/adego/core/model/Participant.kt
+++ b/core/model/src/main/kotlin/com/teammanduk/adego/core/model/Participant.kt
@@ -8,5 +8,6 @@ data class Participant(
     val name: String,
     val profileColor: String, // 색상 hex 코드 (예: "#E53935")
     val location: ParticipantLocation? = null,
-    val route: ParticipantRoute? = null
+    val route: ParticipantRoute? = null,
+    val distanceToDestination: Int? = null // 약속장소까지의 거리 (미터), Repository에서 계산
 )

--- a/core/model/src/main/kotlin/com/teammanduk/adego/core/model/ParticipantLocation.kt
+++ b/core/model/src/main/kotlin/com/teammanduk/adego/core/model/ParticipantLocation.kt
@@ -1,0 +1,11 @@
+package com.teammanduk.adego.core.model
+
+/**
+ * 참여자 위치 정보
+ */
+data class ParticipantLocation(
+    val latitude: Double,
+    val longitude: Double,
+    val updatedAt: Long,
+    val accuracy: Float = 0f
+)

--- a/core/model/src/main/kotlin/com/teammanduk/adego/core/model/ParticipantRoute.kt
+++ b/core/model/src/main/kotlin/com/teammanduk/adego/core/model/ParticipantRoute.kt
@@ -1,0 +1,13 @@
+package com.teammanduk.adego.core.model
+
+/**
+ * 참여자 경로 정보 (현재 위치 → 목적지)
+ */
+data class ParticipantRoute(
+    val eta: String, // "15분"
+    val distance: String, // "3.2km"
+    val polyline: String, // 인코딩된 경로
+    val durationInSeconds: Int = 0,
+    val distanceInMeters: Int = 0,
+    val updatedAt: Long
+)

--- a/core/model/src/main/kotlin/com/teammanduk/adego/core/model/Room.kt
+++ b/core/model/src/main/kotlin/com/teammanduk/adego/core/model/Room.kt
@@ -1,0 +1,14 @@
+package com.teammanduk.adego.core.model
+
+/**
+ * 방 정보 (정적 데이터)
+ * 참여자 정보는 별도로 실시간 구독
+ */
+data class Room(
+    val roomId: String,
+    val roomName: String,
+    val destination: Place,
+    val dateTime: String,
+    val createdBy: String,
+    val createdAt: Long
+)

--- a/core/navigation/src/main/kotlin/com/teammanduk/adego/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/kotlin/com/teammanduk/adego/core/navigation/RouteModel.kt
@@ -17,6 +17,8 @@ sealed interface Route {
 
     @Serializable
     data class Map(
+        val roomId: String,
+        val userId: String,
         val hour: Int,
         val minute: Int
     ): Route

--- a/core/remote/build.gradle.kts
+++ b/core/remote/build.gradle.kts
@@ -10,4 +10,12 @@ setNamespace("core.remote")
 dependencies {
     implementation(projects.core.dataApi)
     implementation(libs.kotlinx.serialization.json)
+
+    // Firebase
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.database.ktx)
+    implementation(libs.firebase.auth.ktx)
+
+    // Location Services
+    implementation(libs.play.services.location)
 }

--- a/core/remote/src/main/kotlin/com/teammanduk/adego/core/remote/datasource/FirebaseRoomDataSource.kt
+++ b/core/remote/src/main/kotlin/com/teammanduk/adego/core/remote/datasource/FirebaseRoomDataSource.kt
@@ -1,0 +1,260 @@
+package com.teammanduk.adego.core.remote.datasource
+
+import android.util.Log
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+import com.teammanduk.adego.core.data_api.datasource.RoomDataSource
+import com.teammanduk.adego.core.data_api.model.ParticipantDto
+import com.teammanduk.adego.core.data_api.model.RoomDto
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.random.Random
+
+@Singleton
+class FirebaseRoomDataSource @Inject constructor() : RoomDataSource {
+
+    private val database: DatabaseReference by lazy {
+        Log.d(TAG, "[Firebase] DatabaseReference 초기화 중...")
+        try {
+            val firebaseDatabase = FirebaseDatabase.getInstance()
+            val databaseUrl = firebaseDatabase.reference.toString()
+            Log.d(TAG, "[Firebase] Database URL: $databaseUrl")
+
+            val ref = firebaseDatabase.reference
+            Log.d(TAG, "[Firebase] DatabaseReference 초기화 완료: ${ref.database.app.name}")
+            ref
+        } catch (e: Exception) {
+            Log.e(TAG, "[Firebase] DatabaseReference 초기화 실패!", e)
+            throw e
+        }
+    }
+
+    override suspend fun createRoom(roomDto: RoomDto): Result<Unit> {
+        return try {
+            Log.d(TAG, "[Firebase] Room 저장 시작: ${roomDto.roomId}")
+            database.child("rooms")
+                .child(roomDto.roomId)
+                .setValue(roomDto)
+                .await()
+
+            Log.d(TAG, "[Firebase] Room 저장 완료: ${roomDto.roomId}")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "[Firebase] Room 저장 실패", e)
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getRoom(roomId: String): Result<RoomDto?> {
+        return try {
+            val snapshot = database.child("rooms")
+                .child(roomId)
+                .get()
+                .await()
+
+            val room = snapshot.getValue(RoomDto::class.java)
+            Log.d(TAG, "Room fetched: $roomId")
+            Result.success(room)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to fetch room", e)
+            Result.failure(e)
+        }
+    }
+
+    override fun observeRoom(roomId: String): Flow<RoomDto?> = callbackFlow {
+        val listener = object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) {
+                val room = snapshot.getValue(RoomDto::class.java)
+                trySend(room)
+            }
+
+            override fun onCancelled(error: DatabaseError) {
+                Log.e(TAG, "Room observation cancelled", error.toException())
+                close(error.toException())
+            }
+        }
+
+        val ref = database.child("rooms").child(roomId)
+        ref.addValueEventListener(listener)
+
+        awaitClose {
+            ref.removeEventListener(listener)
+        }
+    }
+
+    override suspend fun addParticipant(
+        roomId: String,
+        participantDto: ParticipantDto
+    ): Result<Unit> {
+        return try {
+            Log.d(TAG, "[Firebase] 참여자 추가 시작: ${participantDto.userId} -> room $roomId")
+            database.child("participants")
+                .child(roomId)
+                .child(participantDto.userId)
+                .setValue(participantDto)
+                .await()
+
+            Log.d(TAG, "[Firebase] 참여자 추가 완료: ${participantDto.userId}")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "[Firebase] 참여자 추가 실패", e)
+            Result.failure(e)
+        }
+    }
+
+    override fun observeParticipants(roomId: String): Flow<List<ParticipantDto>> = callbackFlow {
+        val listener = object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) {
+                val participants = mutableListOf<ParticipantDto>()
+                snapshot.children.forEach { child ->
+                    child.getValue(ParticipantDto::class.java)?.let {
+                        participants.add(it)
+                    }
+                }
+                trySend(participants)
+            }
+
+            override fun onCancelled(error: DatabaseError) {
+                Log.e(TAG, "Participants observation cancelled", error.toException())
+                close(error.toException())
+            }
+        }
+
+        val ref = database.child("participants").child(roomId)
+        ref.addValueEventListener(listener)
+
+        awaitClose {
+            ref.removeEventListener(listener)
+        }
+    }
+
+    override suspend fun updateParticipantLocation(
+        roomId: String,
+        userId: String,
+        latitude: Double,
+        longitude: Double,
+        accuracy: Float,
+        timestamp: Long
+    ): Result<Unit> {
+        return try {
+            val locationMap = mapOf(
+                "latitude" to latitude,
+                "longitude" to longitude,
+                "accuracy" to accuracy,
+                "updatedAt" to timestamp
+            )
+
+            database.child("participants")
+                .child(roomId)
+                .child(userId)
+                .child("location")
+                .setValue(locationMap)
+                .await()
+
+            Log.d(TAG, "Location updated for user $userId in room $roomId")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to update location", e)
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun updateParticipantRoute(
+        roomId: String,
+        userId: String,
+        eta: String,
+        distance: String,
+        polyline: String,
+        durationInSeconds: Int,
+        distanceInMeters: Int,
+        timestamp: Long
+    ): Result<Unit> {
+        return try {
+            val routeMap = mapOf(
+                "eta" to eta,
+                "distance" to distance,
+                "polyline" to polyline,
+                "durationInSeconds" to durationInSeconds,
+                "distanceInMeters" to distanceInMeters,
+                "updatedAt" to timestamp
+            )
+
+            database.child("participants")
+                .child(roomId)
+                .child(userId)
+                .child("route")
+                .setValue(routeMap)
+                .await()
+
+            Log.d(TAG, "Route updated for user $userId in room $roomId")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to update route", e)
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun removeParticipant(roomId: String, userId: String): Result<Unit> {
+        return try {
+            database.child("participants")
+                .child(roomId)
+                .child(userId)
+                .removeValue()
+                .await()
+
+            Log.d(TAG, "Participant removed: $userId from room $roomId")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to remove participant", e)
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun generateUniqueRoomId(): String {
+        var roomId: String
+        var exists: Boolean
+
+        Log.d(TAG, "[Firebase] 고유 roomId 생성 시작")
+        try {
+            do {
+                // 6자리 영숫자 코드 생성 (대문자 + 숫자)
+                roomId = generateRandomCode()
+                Log.d(TAG, "[Firebase] 랜덤 코드 생성: $roomId")
+
+                // 중복 체크
+                Log.d(TAG, "[Firebase] Firebase에서 중복 체크 시작: rooms/$roomId")
+                val snapshot = database.child("rooms")
+                    .child(roomId)
+                    .get()
+                    .await()
+
+                exists = snapshot.exists()
+                Log.d(TAG, "[Firebase] 중복 체크 결과: exists=$exists")
+            } while (exists)
+
+            Log.d(TAG, "[Firebase] 고유 roomId 생성 완료: $roomId")
+            return roomId
+        } catch (e: Exception) {
+            Log.e(TAG, "[Firebase] roomId 생성 중 에러 발생", e)
+            throw e
+        }
+    }
+
+    private fun generateRandomCode(): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        return (1..6)
+            .map { chars[Random.nextInt(chars.length)] }
+            .joinToString("")
+    }
+
+    companion object {
+        private const val TAG = "AdegoRoom"
+    }
+}

--- a/core/remote/src/main/kotlin/com/teammanduk/adego/core/remote/datasource/FirebaseRoomDataSource.kt
+++ b/core/remote/src/main/kotlin/com/teammanduk/adego/core/remote/datasource/FirebaseRoomDataSource.kt
@@ -95,6 +95,7 @@ class FirebaseRoomDataSource @Inject constructor() : RoomDataSource {
     ): Result<Unit> {
         return try {
             Log.d(TAG, "[Firebase] 참여자 추가 시작: ${participantDto.userId} -> room $roomId")
+            Log.d(TAG, "[Firebase] 참여자 정보 - name: ${participantDto.name}, profileColor: ${participantDto.profileColor}")
             database.child("participants")
                 .child(roomId)
                 .child(participantDto.userId)
@@ -114,10 +115,12 @@ class FirebaseRoomDataSource @Inject constructor() : RoomDataSource {
             override fun onDataChange(snapshot: DataSnapshot) {
                 val participants = mutableListOf<ParticipantDto>()
                 snapshot.children.forEach { child ->
-                    child.getValue(ParticipantDto::class.java)?.let {
-                        participants.add(it)
+                    child.getValue(ParticipantDto::class.java)?.let { participant ->
+                        Log.d(TAG, "[Firebase] 참여자 불러옴 - userId: ${participant.userId}, name: ${participant.name}, profileColor: ${participant.profileColor}")
+                        participants.add(participant)
                     }
                 }
+                Log.d(TAG, "[Firebase] 총 ${participants.size}명의 참여자 불러옴")
                 trySend(participants)
             }
 

--- a/core/remote/src/main/kotlin/com/teammanduk/adego/core/remote/datasource/FusedLocationDataSource.kt
+++ b/core/remote/src/main/kotlin/com/teammanduk/adego/core/remote/datasource/FusedLocationDataSource.kt
@@ -1,0 +1,139 @@
+package com.teammanduk.adego.core.remote.datasource
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.location.Location
+import android.os.Looper
+import android.util.Log
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.teammanduk.adego.core.data_api.datasource.LocationDataSource
+import com.teammanduk.adego.core.data_api.model.ParticipantLocationDto
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+@Singleton
+class FusedLocationDataSource @Inject constructor(
+    @ApplicationContext private val context: Context
+) : LocationDataSource {
+
+    private val fusedLocationClient: FusedLocationProviderClient =
+        LocationServices.getFusedLocationProviderClient(context)
+
+    private var locationCallback: LocationCallback? = null
+
+    @SuppressLint("MissingPermission")
+    override suspend fun getCurrentLocation(): Result<ParticipantLocationDto> {
+        return try {
+            suspendCancellableCoroutine { continuation ->
+                fusedLocationClient.lastLocation
+                    .addOnSuccessListener { location: Location? ->
+                        if (location != null) {
+                            val locationDto = location.toDto()
+                            Log.d(TAG, "Current location: $locationDto")
+                            continuation.resume(Result.success(locationDto))
+                        } else {
+                            Log.w(TAG, "Location is null")
+                            continuation.resume(
+                                Result.failure(Exception("Location is null"))
+                            )
+                        }
+                    }
+                    .addOnFailureListener { exception ->
+                        Log.e(TAG, "Failed to get current location", exception)
+                        continuation.resume(Result.failure(exception))
+                    }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting current location", e)
+            Result.failure(e)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    override fun getLocationUpdates(): Flow<ParticipantLocationDto> = callbackFlow {
+        val locationRequest = LocationRequest.Builder(
+            Priority.PRIORITY_HIGH_ACCURACY,
+            LOCATION_UPDATE_INTERVAL
+        ).apply {
+            setMinUpdateIntervalMillis(FASTEST_LOCATION_INTERVAL)
+            setWaitForAccurateLocation(false)
+        }.build()
+
+        val callback = object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                result.locations.lastOrNull()?.let { location ->
+                    val locationDto = location.toDto()
+                    Log.d(TAG, "Location update: $locationDto")
+                    trySend(locationDto)
+                }
+            }
+        }
+
+        locationCallback = callback
+
+        fusedLocationClient.requestLocationUpdates(
+            locationRequest,
+            callback,
+            Looper.getMainLooper()
+        ).addOnFailureListener { exception ->
+            Log.e(TAG, "Failed to request location updates", exception)
+            close(exception)
+        }
+
+        awaitClose {
+            fusedLocationClient.removeLocationUpdates(callback)
+            locationCallback = null
+            Log.d(TAG, "Location updates stopped")
+        }
+    }
+
+    override suspend fun startTracking(): Result<Unit> {
+        return try {
+            Log.d(TAG, "Location tracking started")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start tracking", e)
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun stopTracking(): Result<Unit> {
+        return try {
+            locationCallback?.let {
+                fusedLocationClient.removeLocationUpdates(it)
+                locationCallback = null
+            }
+            Log.d(TAG, "Location tracking stopped")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to stop tracking", e)
+            Result.failure(e)
+        }
+    }
+
+    private fun Location.toDto(): ParticipantLocationDto {
+        return ParticipantLocationDto(
+            latitude = latitude,
+            longitude = longitude,
+            updatedAt = System.currentTimeMillis(),
+            accuracy = accuracy
+        )
+    }
+
+    companion object {
+        private const val TAG = "FusedLocationDataSource"
+        private const val LOCATION_UPDATE_INTERVAL = 5000L // 5초
+        private const val FASTEST_LOCATION_INTERVAL = 2000L // 2초
+    }
+}

--- a/core/remote/src/main/kotlin/com/teammanduk/adego/core/remote/di/RemoteModule.kt
+++ b/core/remote/src/main/kotlin/com/teammanduk/adego/core/remote/di/RemoteModule.kt
@@ -1,0 +1,27 @@
+package com.teammanduk.adego.core.remote.di
+
+import com.teammanduk.adego.core.data_api.datasource.LocationDataSource
+import com.teammanduk.adego.core.data_api.datasource.RoomDataSource
+import com.teammanduk.adego.core.remote.datasource.FirebaseRoomDataSource
+import com.teammanduk.adego.core.remote.datasource.FusedLocationDataSource
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RemoteModule {
+    @Binds
+    @Singleton
+    abstract fun bindRoomDataSource(
+        firebaseRoomDataSource: FirebaseRoomDataSource
+    ): RoomDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindLocationDataSource(
+        fusedLocationDataSource: FusedLocationDataSource
+    ): LocationDataSource
+}

--- a/feature/create/src/main/kotlin/com/teammanduk/adego/feature/create/CreateScreen.kt
+++ b/feature/create/src/main/kotlin/com/teammanduk/adego/feature/create/CreateScreen.kt
@@ -50,18 +50,54 @@ import java.util.Locale
 internal fun CreateRoute(
     onNavigateBack: () -> Unit = {},
     onNavigateToSelectPlace: () -> Unit = {},
-    onCreateMeeting: (String, Int, Int) -> Unit = { _, _, _ -> },
+    onNavigateToMap: (String, String, Int, Int) -> Unit = { _, _, _, _ -> },  // roomId, userId, hour, minute으로 Map 화면 이동
     selectedPlaceFromNav: String? = null,
     viewModel: CreateViewModel = hiltViewModel()
 ) {
     val selectedPlace by viewModel.selectedPlace.collectAsStateWithLifecycle()
+    val isCreating by viewModel.isCreating.collectAsStateWithLifecycle()
+    val createdRoomInfo by viewModel.createdRoomInfo.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
+
+    // 방 생성 성공 시 Map 화면으로 이동
+    androidx.compose.runtime.LaunchedEffect(createdRoomInfo) {
+        createdRoomInfo?.let { info ->
+            onNavigateToMap(info.roomId, info.userId, info.hour, info.minute)
+            viewModel.clearCreatedRoomInfo()
+        }
+    }
+
+    // 에러 표시
+    error?.let { errorMessage ->
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = { viewModel.clearError() },
+            title = { Text("방 생성 실패") },
+            text = { Text(errorMessage) },
+            confirmButton = {
+                androidx.compose.material3.TextButton(onClick = { viewModel.clearError() }) {
+                    Text("확인")
+                }
+            }
+        )
+    }
 
     CreateScreen(
         onNavigateBack = onNavigateBack,
         onNavigateToSelectPlace = onNavigateToSelectPlace,
-        onCreateMeeting = onCreateMeeting,
+        onCreateRoom = { roomName, dateMillis, hour, minute ->
+            // TODO: 실제 userId, userName으로 교체
+            viewModel.createRoom(
+                roomName = roomName,
+                dateMillis = dateMillis,
+                hour = hour,
+                minute = minute,
+                userId = "user_${System.currentTimeMillis()}", // 임시 userId
+                userName = "사용자" // 임시 userName
+            )
+        },
         selectedPlaceFromNav = selectedPlaceFromNav,
-        selectedPlaceFromViewModel = selectedPlace
+        selectedPlaceFromViewModel = selectedPlace,
+        isCreating = isCreating
     )
 }
 
@@ -69,15 +105,21 @@ internal fun CreateRoute(
 private fun CreateScreen(
     onNavigateBack: () -> Unit,
     onNavigateToSelectPlace: () -> Unit,
-    onCreateMeeting: (String, Int, Int) -> Unit,
+    onCreateRoom: (roomName: String, dateMillis: Long, hour: Int, minute: Int) -> Unit,
     selectedPlaceFromNav: String? = null,
-    selectedPlaceFromViewModel: com.teammanduk.adego.core.model.Place? = null
+    selectedPlaceFromViewModel: com.teammanduk.adego.core.model.Place? = null,
+    isCreating: Boolean = false
 ) {
     // ViewModel에서 전달받은 장소 정보 사용
     val selectedPlace = selectedPlaceFromViewModel?.name ?: ""
-    var selectedDate by rememberSaveable { mutableStateOf<Long?>(null) }
-    var selectedHour by rememberSaveable { mutableStateOf<Int?>(null) }
-    var selectedMinute by rememberSaveable { mutableStateOf<Int?>(null) }
+    var roomName by rememberSaveable { mutableStateOf("") }
+
+    // 현재 날짜와 시간을 초기값으로 설정
+    val currentCalendar = java.util.Calendar.getInstance()
+    var selectedDate by rememberSaveable { mutableStateOf<Long?>(currentCalendar.timeInMillis) }
+    var selectedHour by rememberSaveable { mutableStateOf<Int?>(currentCalendar.get(java.util.Calendar.HOUR_OF_DAY)) }
+    var selectedMinute by rememberSaveable { mutableStateOf<Int?>(currentCalendar.get(java.util.Calendar.MINUTE)) }
+
     var showDatePicker by rememberSaveable { mutableStateOf(false) }
     var showTimePicker by rememberSaveable { mutableStateOf(false) }
 
@@ -275,9 +317,14 @@ private fun CreateScreen(
             // 모임 생성하기 버튼
             Button(
                 onClick = {
-                    val hour = selectedHour ?: 0
-                    val minute = selectedMinute ?: 0
-                    onCreateMeeting(selectedPlace, hour, minute)
+                    val dateMillis = selectedDate ?: return@Button
+                    val hour = selectedHour ?: return@Button
+                    val minute = selectedMinute ?: return@Button
+
+                    // 방 이름 생성 (장소명 + 시간)
+                    val generatedRoomName = "$selectedPlace 모임"
+
+                    onCreateRoom(generatedRoomName, dateMillis, hour, minute)
                 },
                 modifier = Modifier
                     .fillMaxWidth()
@@ -287,13 +334,20 @@ private fun CreateScreen(
                     containerColor = AdegoTheme.colors.main500
                 ),
                 shape = RoundedCornerShape(12.dp),
-                enabled = selectedPlace.isNotEmpty() && selectedDate != null && selectedHour != null && selectedMinute != null
+                enabled = !isCreating && selectedPlace.isNotEmpty() && selectedDate != null && selectedHour != null && selectedMinute != null
             ) {
-                Text(
-                    text = "모임 생성하기",
-                    style = AdegoTheme.typography.titleLarge,
-                    color = AdegoTheme.colors.onMain500
-                )
+                if (isCreating) {
+                    androidx.compose.material3.CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = AdegoTheme.colors.onMain500
+                    )
+                } else {
+                    Text(
+                        text = "모임 생성하기",
+                        style = AdegoTheme.typography.titleLarge,
+                        color = AdegoTheme.colors.onMain500
+                    )
+                }
             }
         }
     }
@@ -314,8 +368,8 @@ private fun CreateScreen(
             selectedHour = hour
             selectedMinute = minute
         },
-        initialHour = selectedHour ?: 0,
-        initialMinute = selectedMinute ?: 0
+        initialHour = selectedHour ?: currentCalendar.get(java.util.Calendar.HOUR_OF_DAY),
+        initialMinute = selectedMinute ?: currentCalendar.get(java.util.Calendar.MINUTE)
     )
 }
 
@@ -326,7 +380,7 @@ private fun CreateScreenPreview() {
         CreateScreen(
             onNavigateBack = {},
             onNavigateToSelectPlace = {},
-            onCreateMeeting = { _, _, _ -> },
+            onCreateRoom = { _, _, _, _ -> },
         )
     }
 }

--- a/feature/create/src/main/kotlin/com/teammanduk/adego/feature/create/CreateViewModel.kt
+++ b/feature/create/src/main/kotlin/com/teammanduk/adego/feature/create/CreateViewModel.kt
@@ -1,18 +1,34 @@
 package com.teammanduk.adego.feature.create
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.teammanduk.adego.core.domain.repository.RoomRepository
 import com.teammanduk.adego.core.domain.usecase.GetSelectedPlaceUseCase
 import com.teammanduk.adego.core.model.Place
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
+
+data class CreatedRoomInfo(
+    val roomId: String,
+    val userId: String,
+    val hour: Int,
+    val minute: Int
+)
 
 @HiltViewModel
 class CreateViewModel @Inject constructor(
-    private val getSelectedPlaceUseCase: GetSelectedPlaceUseCase
+    private val getSelectedPlaceUseCase: GetSelectedPlaceUseCase,
+    private val roomRepository: RoomRepository
 ) : ViewModel() {
 
     val selectedPlace: StateFlow<Place?> = getSelectedPlaceUseCase()
@@ -21,4 +37,90 @@ class CreateViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = null
         )
+
+    private val _isCreating = MutableStateFlow(false)
+    val isCreating: StateFlow<Boolean> = _isCreating.asStateFlow()
+
+    private val _createdRoomInfo = MutableStateFlow<CreatedRoomInfo?>(null)
+    val createdRoomInfo: StateFlow<CreatedRoomInfo?> = _createdRoomInfo.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    /**
+     * 방 생성
+     */
+    fun createRoom(
+        roomName: String,
+        dateMillis: Long,
+        hour: Int,
+        minute: Int,
+        userId: String,  // TODO: 실제 사용자 ID로 교체
+        userName: String // TODO: 실제 사용자 이름으로 교체
+    ) {
+        viewModelScope.launch {
+            try {
+                Log.d(TAG, "[ViewModel] 방 생성 시작: roomName=$roomName, userId=$userId")
+                _isCreating.value = true
+                _error.value = null
+
+                val place = selectedPlace.value
+                    ?: throw IllegalStateException("장소가 선택되지 않았습니다")
+
+                Log.d(TAG, "[ViewModel] 선택된 장소: ${place.name}")
+
+                // 날짜/시간 포맷팅
+                val dateTime = formatDateTime(dateMillis, hour, minute)
+                Log.d(TAG, "[ViewModel] 포맷팅된 날짜/시간: $dateTime")
+
+                // 방 생성
+                Log.d(TAG, "[ViewModel] RoomRepository.createRoom() 호출 시작")
+                val result = roomRepository.createRoom(
+                    roomName = roomName,
+                    destination = place,
+                    dateTime = dateTime,
+                    userId = userId,
+                    userName = userName
+                )
+
+                result.onSuccess { roomId ->
+                    Log.d(TAG, "[ViewModel] 방 생성 성공! roomId=$roomId")
+                    _createdRoomInfo.value = CreatedRoomInfo(
+                        roomId = roomId,
+                        userId = userId,
+                        hour = hour,
+                        minute = minute
+                    )
+                }.onFailure { exception ->
+                    Log.e(TAG, "[ViewModel] 방 생성 실패", exception)
+                    _error.value = exception.message ?: "방 생성에 실패했습니다"
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "[ViewModel] 방 생성 중 예외 발생", e)
+                _error.value = e.message ?: "알 수 없는 오류가 발생했습니다"
+            } finally {
+                _isCreating.value = false
+                Log.d(TAG, "[ViewModel] 방 생성 프로세스 종료")
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "AdegoRoom"
+    }
+
+    private fun formatDateTime(dateMillis: Long, hour: Int, minute: Int): String {
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
+        val date = dateFormat.format(Date(dateMillis))
+        val time = String.format("%02d:%02d:00", hour, minute)
+        return "${date}T$time"
+    }
+
+    fun clearCreatedRoomInfo() {
+        _createdRoomInfo.value = null
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
 }

--- a/feature/create/src/main/kotlin/com/teammanduk/adego/feature/create/navigation/CreateNavigation.kt
+++ b/feature/create/src/main/kotlin/com/teammanduk/adego/feature/create/navigation/CreateNavigation.kt
@@ -32,7 +32,7 @@ fun NavGraphBuilder.createNavGraph(
     navController: NavController,
     onNavigateBack: () -> Unit,
     onNavigateToSelectPlace: () -> Unit,
-    onCreateMeeting: (String, Int, Int) -> Unit,
+    onCreateMeeting: (String, String, Int, Int) -> Unit,
 ) {
     composable<Route.Create> { backStackEntry ->
         val selectedPlace = navController.currentBackStackEntry
@@ -43,7 +43,9 @@ fun NavGraphBuilder.createNavGraph(
         CreateRoute(
             onNavigateBack = onNavigateBack,
             onNavigateToSelectPlace = onNavigateToSelectPlace,
-            onCreateMeeting = onCreateMeeting,
+            onNavigateToMap = { roomId, userId, hour, minute ->
+                onCreateMeeting(roomId, userId, hour, minute)
+            },
             selectedPlaceFromNav = selectedPlace?.value,
         )
     }

--- a/feature/home/src/main/kotlin/com/teammanduk/adego/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/teammanduk/adego/feature/home/HomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -31,18 +32,48 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
 
 @Composable
 internal fun HomeRoute(
     onNavigateToCreate: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
-    onJoinWithCode: (String) -> Unit = {},
+    onNavigateToMap: (String, String, Int, Int) -> Unit = { _, _, _, _ -> },
+    viewModel: HomeViewModel = hiltViewModel()
 ) {
+    val isJoining by viewModel.isJoining.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
+    val joinedRoomInfo by viewModel.joinedRoomInfo.collectAsStateWithLifecycle()
+
+    // 방 참여 성공 시 Map 화면으로 이동
+    androidx.compose.runtime.LaunchedEffect(joinedRoomInfo) {
+        joinedRoomInfo?.let { info ->
+            onNavigateToMap(info.roomId, info.userId, info.hour, info.minute)
+            viewModel.clearJoinedRoomInfo()
+        }
+    }
+
+    // 에러 표시
+    error?.let { errorMessage ->
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = { viewModel.clearError() },
+            title = { Text("방 참여 실패") },
+            text = { Text(errorMessage) },
+            confirmButton = {
+                androidx.compose.material3.TextButton(onClick = { viewModel.clearError() }) {
+                    Text("확인")
+                }
+            }
+        )
+    }
+
     HomeScreen(
         onNavigateToCreate = onNavigateToCreate,
         onNavigateToSettings = onNavigateToSettings,
-        onJoinWithCode = onJoinWithCode,
+        onJoinWithCode = { code -> viewModel.joinRoomWithCode(code) },
+        isJoining = isJoining
     )
 }
 
@@ -51,6 +82,7 @@ private fun HomeScreen(
     onNavigateToCreate: () -> Unit,
     onNavigateToSettings: () -> Unit,
     onJoinWithCode: (String) -> Unit,
+    isJoining: Boolean = false
 ) {
     var inviteCode by remember { mutableStateOf("") }
 
@@ -156,13 +188,20 @@ private fun HomeScreen(
                         containerColor = AdegoTheme.colors.main500
                     ),
                     shape = RoundedCornerShape(8.dp),
-                    enabled = inviteCode.isNotEmpty()
+                    enabled = inviteCode.isNotEmpty() && !isJoining
                 ) {
-                    Text(
-                        text = "입장",
-                        style = AdegoTheme.typography.titleSmall,
-                        color = AdegoTheme.colors.onMain500
-                    )
+                    if (isJoining) {
+                        androidx.compose.material3.CircularProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            color = AdegoTheme.colors.onMain500
+                        )
+                    } else {
+                        Text(
+                            text = "입장",
+                            style = AdegoTheme.typography.titleSmall,
+                            color = AdegoTheme.colors.onMain500
+                        )
+                    }
                 }
             }
 

--- a/feature/home/src/main/kotlin/com/teammanduk/adego/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/teammanduk/adego/feature/home/HomeViewModel.kt
@@ -60,6 +60,7 @@ class HomeViewModel @Inject constructor(
                         val tempUserName = "사용자"
 
                         // 3. 방 참여
+                        Log.d(TAG, "[HomeViewModel] 방 참여 시도 - userId: $tempUserId, userName: $tempUserName")
                         val joinResult = roomRepository.joinRoom(
                             roomId = inviteCode,
                             userId = tempUserId,

--- a/feature/home/src/main/kotlin/com/teammanduk/adego/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/teammanduk/adego/feature/home/HomeViewModel.kt
@@ -1,0 +1,117 @@
+package com.teammanduk.adego.feature.home
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.teammanduk.adego.core.domain.repository.RoomRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+private const val TAG = "A-degoLogTag"
+
+data class RoomJoinInfo(
+    val roomId: String,
+    val userId: String,
+    val hour: Int,
+    val minute: Int
+)
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val roomRepository: RoomRepository
+) : ViewModel() {
+
+    private val _isJoining = MutableStateFlow(false)
+    val isJoining: StateFlow<Boolean> = _isJoining.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private val _joinedRoomInfo = MutableStateFlow<RoomJoinInfo?>(null)
+    val joinedRoomInfo: StateFlow<RoomJoinInfo?> = _joinedRoomInfo.asStateFlow()
+
+    fun joinRoomWithCode(inviteCode: String) {
+        Log.d(TAG, "[HomeViewModel] 초대코드로 방 참여 시도: $inviteCode")
+
+        viewModelScope.launch {
+            _isJoining.value = true
+
+            try {
+                // 1. 방 존재 여부 확인
+                val roomResult = roomRepository.getRoomInfo(inviteCode)
+
+                roomResult.fold(
+                    onSuccess = { room ->
+                        if (room == null) {
+                            Log.w(TAG, "[HomeViewModel] 방을 찾을 수 없음: $inviteCode")
+                            _error.value = "존재하지 않는 초대 코드입니다."
+                            _isJoining.value = false
+                            return@launch
+                        }
+
+                        Log.d(TAG, "[HomeViewModel] 방 정보 조회 성공: ${room.roomName}")
+
+                        // 2. 임시 userId 생성
+                        val tempUserId = "user_${System.currentTimeMillis()}"
+                        val tempUserName = "사용자"
+
+                        // 3. 방 참여
+                        val joinResult = roomRepository.joinRoom(
+                            roomId = inviteCode,
+                            userId = tempUserId,
+                            userName = tempUserName
+                        )
+
+                        joinResult.fold(
+                            onSuccess = {
+                                Log.d(TAG, "[HomeViewModel] 방 참여 성공")
+
+                                // 시간 정보 추출 (예: "2025-01-13 14:30" -> hour=14, minute=30)
+                                val timeParts = room.dateTime.split(" ")
+                                val hourMinute = if (timeParts.size >= 2) {
+                                    val time = timeParts[1].split(":")
+                                    if (time.size >= 2) {
+                                        Pair(time[0].toIntOrNull() ?: 0, time[1].toIntOrNull() ?: 0)
+                                    } else {
+                                        Pair(0, 0)
+                                    }
+                                } else {
+                                    Pair(0, 0)
+                                }
+
+                                _joinedRoomInfo.value = RoomJoinInfo(
+                                    roomId = inviteCode,
+                                    userId = tempUserId,
+                                    hour = hourMinute.first,
+                                    minute = hourMinute.second
+                                )
+                            },
+                            onFailure = { exception ->
+                                Log.e(TAG, "[HomeViewModel] 방 참여 실패", exception)
+                                _error.value = "방 참여에 실패했습니다: ${exception.message}"
+                            }
+                        )
+                    },
+                    onFailure = { exception ->
+                        Log.e(TAG, "[HomeViewModel] 방 정보 조회 실패", exception)
+                        _error.value = "방 정보를 가져올 수 없습니다: ${exception.message}"
+                    }
+                )
+            } finally {
+                _isJoining.value = false
+            }
+        }
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+
+    fun clearJoinedRoomInfo() {
+        _joinedRoomInfo.value = null
+    }
+}

--- a/feature/home/src/main/kotlin/com/teammanduk/adego/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/kotlin/com/teammanduk/adego/feature/home/navigation/HomeNavigation.kt
@@ -16,13 +16,13 @@ fun NavController.navigateToHome(
 fun NavGraphBuilder.homeNavGraph(
     onNavigateToCreate: () -> Unit,
     onNavigateToSettings: () -> Unit,
-    onJoinWithCode: (String) -> Unit,
+    onNavigateToMap: (String, String, Int, Int) -> Unit,
 ) {
     composable<Route.Home> {
         HomeRoute(
             onNavigateToCreate = onNavigateToCreate,
             onNavigateToSettings = onNavigateToSettings,
-            onJoinWithCode = onJoinWithCode,
+            onNavigateToMap = onNavigateToMap,
         )
     }
 }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     implementation(projects.feature.create)
     implementation(projects.feature.map)
     implementation(projects.core.data)
+    implementation(projects.core.remote)
 }

--- a/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainNavHost.kt
+++ b/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainNavHost.kt
@@ -28,12 +28,7 @@ internal fun MainNavHost(
             homeNavGraph(
                 onNavigateToCreate = navigator::navigateToCreate,
                 onNavigateToSettings = { /* TODO: 설정 화면 구현 */ },
-                onJoinWithCode = { code ->
-                    // TODO: 초대 코드로 서버에서 모임 정보 조회 후 시간, userId 정보 가져오기
-                    // 임시: 코드를 roomId로, 임시 userId 생성, 기본 시간(0시 0분)으로 Map 화면 이동
-                    val tempUserId = "user_${System.currentTimeMillis()}"
-                    navigator.navigateToMap(code, tempUserId, 0, 0)
-                }
+                onNavigateToMap = navigator::navigateToMap
             )
             createNavGraph(
                 navController = navigator.navController,

--- a/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainNavHost.kt
+++ b/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainNavHost.kt
@@ -29,18 +29,18 @@ internal fun MainNavHost(
                 onNavigateToCreate = navigator::navigateToCreate,
                 onNavigateToSettings = { /* TODO: 설정 화면 구현 */ },
                 onJoinWithCode = { code ->
-                    // TODO: 초대 코드로 서버에서 모임 정보 조회 후 시간 정보 가져오기
-                    // 임시: 기본 시간(0시 0분)으로 Map 화면 이동
-                    navigator.navigateToMap(0, 0)
+                    // TODO: 초대 코드로 서버에서 모임 정보 조회 후 시간, userId 정보 가져오기
+                    // 임시: 코드를 roomId로, 임시 userId 생성, 기본 시간(0시 0분)으로 Map 화면 이동
+                    val tempUserId = "user_${System.currentTimeMillis()}"
+                    navigator.navigateToMap(code, tempUserId, 0, 0)
                 }
             )
             createNavGraph(
                 navController = navigator.navController,
                 onNavigateBack = navigator::navigateBack,
                 onNavigateToSelectPlace = navigator::navigateToSelectPlace,
-                onCreateMeeting = { place, hour, minute ->
-                    /* TODO: 모임 생성 로직 구현 */
-                    navigator.navigateToMap(hour, minute)
+                onCreateMeeting = { roomId, userId, hour, minute ->
+                    navigator.navigateToMap(roomId, userId, hour, minute)
                 }
             )
             mapNavGraph()

--- a/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/navigation/MainNavigator.kt
+++ b/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/navigation/MainNavigator.kt
@@ -40,8 +40,8 @@ internal class MainNavigator(
         navController.navigateToSelectPlace()
     }
 
-    fun navigateToMap(hour: Int, minute: Int) {
-        navController.navigateToMap(hour, minute, navOptions)
+    fun navigateToMap(roomId: String, userId: String, hour: Int, minute: Int) {
+        navController.navigateToMap(roomId, userId, hour, minute, navOptions)
     }
 
     fun navigateBack() {

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapIntent.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapIntent.kt
@@ -1,0 +1,16 @@
+package com.teammanduk.adego.feature.map
+
+/**
+ * 지도 화면의 사용자 액션 (Intent)
+ */
+sealed interface MapIntent {
+    // 참가자 선택
+    data class SelectParticipant(val index: Int) : MapIntent
+
+    // 에러 메시지 클리어
+    data object ClearError : MapIntent
+
+    // 초대 다이얼로그 표시/닫기
+    data object ShowInviteDialog : MapIntent
+    data object DismissInviteDialog : MapIntent
+}

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapScreen.kt
@@ -93,7 +93,6 @@ internal fun MapRoute(
     val participants by viewModel.participants.collectAsState()
     val selectedParticipantIndex by viewModel.selectedParticipantIndex.collectAsState()
     val isInitialLocationLoaded by viewModel.isInitialLocationLoaded.collectAsState()
-    val participantDistances by viewModel.participantDistances.collectAsState()
 
     // 위치 권한 요청
     val locationPermissionLauncher = rememberLauncherForActivityResult(
@@ -128,7 +127,6 @@ internal fun MapRoute(
             roomId = roomId,
             meetingTime = meetingTime,
             participants = participants,
-            participantDistances = participantDistances,
             selectedParticipantIndex = selectedParticipantIndex,
             onParticipantSelected = viewModel::onParticipantSelected,
             destination = room?.destination,
@@ -170,7 +168,6 @@ private fun MapScreen(
     roomId: String,
     meetingTime: String,
     participants: List<com.teammanduk.adego.core.model.Participant>,
-    participantDistances: List<ParticipantDistance>,
     selectedParticipantIndex: Int,
     onParticipantSelected: (Int) -> Unit,
     destination: com.teammanduk.adego.core.model.Place?,
@@ -377,14 +374,16 @@ private fun MapScreen(
                     }
                 }
 
-                // 참가자 아이콘들 (거리 기반 위치)
-                participantDistances.forEach { participantDistance ->
-                    val participant = uiParticipants.find {
-                        it.name == participantDistance.participant.name
-                    }
+                // 거리 정보가 있는 참가자들로 필터링 및 정규화
+                val participantsWithDistance = participants.filter { it.distanceToDestination != null }
+                val maxDistance = participantsWithDistance.maxOfOrNull { it.distanceToDestination!! } ?: 1
 
-                    participant?.let { uiParticipant ->
-                        val index = uiParticipants.indexOf(uiParticipant)
+                // 참가자 아이콘들 (거리 기반 위치)
+                participantsWithDistance.forEach { participant ->
+                    val uiParticipant = uiParticipants.find { it.name == participant.name }
+
+                    uiParticipant?.let { uiPart ->
+                        val index = uiParticipants.indexOf(uiPart)
                         val isSelected = pagerState.currentPage == index
 
                         val iconSize by animateDpAsState(
@@ -397,8 +396,14 @@ private fun MapScreen(
                         )
 
                         // normalizedPosition: 0.0f (약속장소) ~ 1.0f (가장 먼 곳)
+                        val normalizedPosition = if (maxDistance > 0) {
+                            (participant.distanceToDestination!!.toFloat() / maxDistance.toFloat()).coerceIn(0f, 1f)
+                        } else {
+                            0f
+                        }
+
                         // 실제 offset 계산: 약속장소 아이콘 너비(32dp) + 여백(8dp) + 비율에 따른 위치
-                        val offsetX = 40.dp + (barWidth - 80.dp) * participantDistance.normalizedPosition
+                        val offsetX = 40.dp + (barWidth - 80.dp) * normalizedPosition
 
                         Box(
                             modifier = Modifier
@@ -409,7 +414,7 @@ private fun MapScreen(
                         ) {
                             // 심장 박동 동심원 애니메이션 (선택된 경우만)
                             if (isSelected) {
-                                val infiniteTransition = rememberInfiniteTransition(label = "pulse_${uiParticipant.name}")
+                                val infiniteTransition = rememberInfiniteTransition(label = "pulse_${uiPart.name}")
                                 val pulseScale by infiniteTransition.animateFloat(
                                     initialValue = 1f,
                                     targetValue = 1.4f,
@@ -431,7 +436,7 @@ private fun MapScreen(
                                     modifier = Modifier
                                         .size(iconSize * pulseScale)
                                         .clip(CircleShape)
-                                        .background(uiParticipant.color.copy(alpha = pulseAlpha))
+                                        .background(uiPart.color.copy(alpha = pulseAlpha))
                                 )
                             }
 
@@ -440,12 +445,12 @@ private fun MapScreen(
                                 modifier = Modifier
                                     .size(iconSize)
                                     .clip(CircleShape)
-                                    .background(uiParticipant.color),
+                                    .background(uiPart.color),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(
                                     imageVector = Icons.Default.Person,
-                                    contentDescription = uiParticipant.name,
+                                    contentDescription = uiPart.name,
                                     tint = Color.White,
                                     modifier = Modifier.size(if (isSelected) 24.dp else 20.dp)
                                 )
@@ -826,7 +831,6 @@ private fun MapScreenPreview() {
             roomId = "preview123",
             meetingTime = "14시 30분",
             participants = emptyList(),
-            participantDistances = emptyList(),
             selectedParticipantIndex = 0,
             onParticipantSelected = {},
             destination = null,

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapScreen.kt
@@ -1,5 +1,8 @@
 package com.teammanduk.adego.feature.map
 
+import android.Manifest
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -44,9 +47,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
-import android.Manifest
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -58,9 +58,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.zIndex
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -73,7 +72,6 @@ import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
 import kotlinx.coroutines.launch
-import kotlin.math.atan2
 
 // 참가자 데이터 클래스
 private data class Participant(
@@ -83,16 +81,14 @@ private data class Participant(
     val color: Color
 )
 
+
 @Composable
 internal fun MapRoute(
     roomId: String,
     meetingTime: String = "00시 00분",
     viewModel: MapViewModel,
 ) {
-    val room by viewModel.room.collectAsState()
-    val participants by viewModel.participants.collectAsState()
-    val selectedParticipantIndex by viewModel.selectedParticipantIndex.collectAsState()
-    val isInitialLocationLoaded by viewModel.isInitialLocationLoaded.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
 
     // 위치 권한 요청
     val locationPermissionLauncher = rememberLauncherForActivityResult(
@@ -119,18 +115,23 @@ internal fun MapRoute(
         )
     }
 
-    // 초기 위치를 로드할 때까지 로딩 화면 표시
-    if (!isInitialLocationLoaded) {
+    // 현재 사용자 찾기
+    val currentUser = uiState.participants.find { it.userId == viewModel.userId }
+
+    // 초기 위치를 로드하고 참가자 정보가 있을 때까지 로딩 화면 표시
+    if (!uiState.isInitialLocationLoaded || uiState.participants.isEmpty() || currentUser?.location == null) {
         LoadingScreen()
     } else {
         MapScreen(
             roomId = roomId,
             meetingTime = meetingTime,
-            participants = participants,
-            selectedParticipantIndex = selectedParticipantIndex,
-            onParticipantSelected = viewModel::onParticipantSelected,
-            destination = room?.destination,
-            currentUserId = viewModel.userId
+            participants = uiState.participants,
+            selectedParticipantIndex = uiState.selectedParticipantIndex,
+            onAction = viewModel::onAction,
+            destination = uiState.room?.destination,
+            currentUserId = viewModel.userId,
+            initialLocation = currentUser.location!!,
+            showInviteDialog = uiState.showInviteDialog
         )
     }
 }
@@ -169,9 +170,11 @@ private fun MapScreen(
     meetingTime: String,
     participants: List<com.teammanduk.adego.core.model.Participant>,
     selectedParticipantIndex: Int,
-    onParticipantSelected: (Int) -> Unit,
+    onAction: (MapIntent) -> Unit,
     destination: com.teammanduk.adego.core.model.Place?,
-    currentUserId: String
+    currentUserId: String,
+    initialLocation: com.teammanduk.adego.core.model.ParticipantLocation,
+    showInviteDialog: Boolean
 ) {
     // 임시: UI 전용 Participant 데이터로 변환
     val uiParticipants = remember(participants) {
@@ -184,7 +187,10 @@ private fun MapScreen(
                     Color(0xFFE53935) // 기본 빨강
                 }
             } catch (e: Exception) {
-                android.util.Log.w("A-degoLogTag", "[MapScreen] profileColor 파싱 실패: ${participant.profileColor}, 기본 색상 사용")
+                android.util.Log.w(
+                    "A-degoLogTag",
+                    "[MapScreen] profileColor 파싱 실패: ${participant.profileColor}, 기본 색상 사용"
+                )
                 Color(0xFFE53935) // 기본 빨강
             }
 
@@ -202,55 +208,63 @@ private fun MapScreen(
         initialPage = selectedParticipantIndex
     )
     val coroutineScope = rememberCoroutineScope()
-    var showInviteDialog by remember { mutableStateOf(false) }
 
     // 현재 사용자 찾기
     val currentUser = remember(participants, currentUserId) {
         participants.find { it.userId == currentUserId }
     }
 
-    // 초기 렌더링 여부 추적
-    var isInitialRender by remember { mutableStateOf(true) }
+    // 초기 카메라 설정 완료 여부
+    var isCameraInitialized by remember { mutableStateOf(false) }
 
-    // 지도 카메라 위치 설정 - 현재 사용자 위치가 반드시 있어야 함
+    // 지도 카메라 위치 설정 (전달받은 초기 위치로 고정)
     val cameraPositionState = rememberCameraPositionState {
-        currentUser?.location?.let { location ->
-            android.util.Log.d("A-degoLogTag", "[MapScreen] 카메라 초기화: 현재 사용자 위치 lat=${location.latitude}, lng=${location.longitude}")
-            position = CameraPosition.fromLatLngZoom(
-                LatLng(location.latitude, location.longitude),
-                15f
-            )
-        } ?: run {
-            // 이 경우는 발생하면 안 됨 (로딩 화면에서 위치를 받은 후에만 여기 도달)
-            android.util.Log.w("A-degoLogTag", "[MapScreen] 경고: 현재 사용자 위치가 없음")
-            position = CameraPosition.fromLatLngZoom(LatLng(37.5665, 126.9780), 15f)
+        android.util.Log.d(
+            "A-degoLogTag",
+            "[MapScreen] 카메라 초기 위치 설정: lat=${initialLocation.latitude}, lng=${initialLocation.longitude}"
+        )
+        position = CameraPosition.fromLatLngZoom(
+            LatLng(initialLocation.latitude, initialLocation.longitude),
+            15f
+        )
+    }
+
+    // pagerState 변경을 ViewModel과 동기화 (pagerState -> ViewModel)
+    LaunchedEffect(pagerState.currentPage) {
+        if (pagerState.currentPage != selectedParticipantIndex) {
+            onAction(MapIntent.SelectParticipant(pagerState.currentPage))
         }
     }
 
-    // 현재 사용자의 위치가 업데이트되면 카메라 이동 (초기 렌더링은 제외)
-    LaunchedEffect(currentUser?.location) {
-        currentUser?.location?.let { location ->
-            if (isInitialRender) {
-                // 초기 렌더링: 애니메이션 없이 바로 이동
-                android.util.Log.d("A-degoLogTag", "[MapScreen] 초기 카메라 위치 설정: lat=${location.latitude}, lng=${location.longitude}")
-                cameraPositionState.move(
-                    com.google.android.gms.maps.CameraUpdateFactory.newLatLngZoom(
-                        LatLng(location.latitude, location.longitude),
-                        15f
-                    )
+    // ViewModel 상태를 pagerState와 동기화 (ViewModel -> pagerState)
+    LaunchedEffect(selectedParticipantIndex) {
+        if (pagerState.currentPage != selectedParticipantIndex) {
+            pagerState.animateScrollToPage(selectedParticipantIndex)
+        }
+    }
+
+    // 참가자 선택 시 해당 위치로 카메라 이동
+    LaunchedEffect(selectedParticipantIndex) {
+        // 초기화 완료 후에만 카메라 이동 (첫 렌더링 이후)
+        if (isCameraInitialized) {
+            val selectedParticipant = participants.getOrNull(selectedParticipantIndex)
+            selectedParticipant?.location?.let { location ->
+                android.util.Log.d(
+                    "A-degoLogTag",
+                    "[MapScreen] 참가자 선택됨 - ${selectedParticipant.name}, 카메라 이동: lat=${location.latitude}, lng=${location.longitude}"
                 )
-                isInitialRender = false
-            } else {
-                // 이후 업데이트: 부드럽게 애니메이션
-                android.util.Log.d("A-degoLogTag", "[MapScreen] 현재 사용자 위치 업데이트: lat=${location.latitude}, lng=${location.longitude}")
                 cameraPositionState.animate(
                     com.google.android.gms.maps.CameraUpdateFactory.newLatLngZoom(
                         LatLng(location.latitude, location.longitude),
                         15f
                     ),
-                    durationMs = 1000
+                    durationMs = 500
                 )
             }
+        } else {
+            // 첫 렌더링에서는 초기화만 하고 카메라 이동하지 않음
+            isCameraInitialized = true
+            android.util.Log.d("A-degoLogTag", "[MapScreen] 카메라 초기화 완료")
         }
     }
 
@@ -282,6 +296,30 @@ private fun MapScreen(
                     title = it.name,
                     snippet = "목적지"
                 )
+            }
+
+            // 참가자 마커들 (네이티브 Marker 사용)
+            participants.forEach { participant ->
+                androidx.compose.runtime.key(participant.userId) {
+                    participant.location?.let { location ->
+                        val uiParticipant = uiParticipants.find { it.name == participant.name }
+                        val isSelected =
+                            uiParticipants.getOrNull(pagerState.currentPage)?.name == participant.name
+
+                        uiParticipant?.let { uiPart ->
+                            val markerIcon = createParticipantMarkerIcon(uiPart.color, isSelected)
+
+                            com.google.maps.android.compose.Marker(
+                                state = com.google.maps.android.compose.rememberMarkerState(
+                                    position = LatLng(location.latitude, location.longitude)
+                                ),
+                                title = participant.name,
+                                icon = markerIcon,
+                                anchor = androidx.compose.ui.geometry.Offset(0.5f, 0.5f)
+                            )
+                        }
+                    }
+                }
             }
         }
 
@@ -329,7 +367,7 @@ private fun MapScreen(
                             .size(24.dp)
                             .clip(CircleShape)
                             .background(AdegoTheme.colors.highlight500)
-                            .clickable { showInviteDialog = true },
+                            .clickable { onAction(MapIntent.ShowInviteDialog) },
                         contentAlignment = Alignment.Center
                     ) {
                         Icon(
@@ -343,197 +381,28 @@ private fun MapScreen(
             }
 
             // 참가자 트래킹 바 (거리 기반 배치)
-            BoxWithConstraints(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(
-                        color = Color(0xFFD6E9F5),
-                        shape = RoundedCornerShape(32.dp)
-                    )
-                    .padding(horizontal = 12.dp, vertical = 4.dp)
-                    .height(56.dp)
-            ) {
-                val barWidth = maxWidth - 24.dp // padding 제외한 실제 트래킹바 너비
-
-                // 약속장소 아이콘 (왼쪽 끝, 0%)
-                destination?.let {
-                    Box(
-                        modifier = Modifier
-                            .align(Alignment.CenterStart)
-                            .size(32.dp)
-                            .clip(CircleShape)
-                            .background(AdegoTheme.colors.main500),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.LocationOn,
-                            contentDescription = "약속장소",
-                            tint = Color.White,
-                            modifier = Modifier.size(20.dp)
-                        )
+            ParticipantTrackingBar(
+                participants = participants,
+                uiParticipants = uiParticipants,
+                destination = destination,
+                pagerState = pagerState,
+                onParticipantClick = { index ->
+                    coroutineScope.launch {
+                        pagerState.animateScrollToPage(index)
                     }
                 }
-
-                // 거리 정보가 있는 참가자들로 필터링 및 정규화
-                val participantsWithDistance = participants.filter { it.distanceToDestination != null }
-                val maxDistance = participantsWithDistance.maxOfOrNull { it.distanceToDestination!! } ?: 1
-
-                // 참가자 아이콘들 (거리 기반 위치)
-                participantsWithDistance.forEach { participant ->
-                    val uiParticipant = uiParticipants.find { it.name == participant.name }
-
-                    uiParticipant?.let { uiPart ->
-                        val index = uiParticipants.indexOf(uiPart)
-                        val isSelected = pagerState.currentPage == index
-
-                        val iconSize by animateDpAsState(
-                            targetValue = if (isSelected) 40.dp else 32.dp,
-                            animationSpec = spring(
-                                dampingRatio = 0.7f,
-                                stiffness = 200f
-                            ),
-                            label = "iconSize"
-                        )
-
-                        // normalizedPosition: 0.0f (약속장소) ~ 1.0f (가장 먼 곳)
-                        val normalizedPosition = if (maxDistance > 0) {
-                            (participant.distanceToDestination!!.toFloat() / maxDistance.toFloat()).coerceIn(0f, 1f)
-                        } else {
-                            0f
-                        }
-
-                        // 실제 offset 계산: 약속장소 아이콘 너비(32dp) + 여백(8dp) + 비율에 따른 위치
-                        val offsetX = 40.dp + (barWidth - 80.dp) * normalizedPosition
-
-                        Box(
-                            modifier = Modifier
-                                .offset(x = offsetX, y = 0.dp)
-                                .size(iconSize)
-                                .align(Alignment.CenterStart),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            // 심장 박동 동심원 애니메이션 (선택된 경우만)
-                            if (isSelected) {
-                                val infiniteTransition = rememberInfiniteTransition(label = "pulse_${uiPart.name}")
-                                val pulseScale by infiniteTransition.animateFloat(
-                                    initialValue = 1f,
-                                    targetValue = 1.4f,
-                                    animationSpec = infiniteRepeatable(
-                                        animation = tween(1000)
-                                    ),
-                                    label = "pulseScale"
-                                )
-                                val pulseAlpha by infiniteTransition.animateFloat(
-                                    initialValue = 0.6f,
-                                    targetValue = 0f,
-                                    animationSpec = infiniteRepeatable(
-                                        animation = tween(1000)
-                                    ),
-                                    label = "pulseAlpha"
-                                )
-
-                                Box(
-                                    modifier = Modifier
-                                        .size(iconSize * pulseScale)
-                                        .clip(CircleShape)
-                                        .background(uiPart.color.copy(alpha = pulseAlpha))
-                                )
-                            }
-
-                            // 메인 아이콘
-                            Box(
-                                modifier = Modifier
-                                    .size(iconSize)
-                                    .clip(CircleShape)
-                                    .background(uiPart.color),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Person,
-                                    contentDescription = uiPart.name,
-                                    tint = Color.White,
-                                    modifier = Modifier.size(if (isSelected) 24.dp else 20.dp)
-                                )
-                            }
-                        }
-                    }
-                }
-            }
+            )
         }
 
-        // 지도 위 참가자 위치 마커들
+        // 지도 위 참가자 위치 마커들 (화면 밖 처리)
         participants.forEach { participant ->
-            participant.location?.let { location ->
-                // 위도/경도를 화면 좌표로 변환
-                val projection = cameraPositionState.projection
-                val screenPosition = projection?.toScreenLocation(
-                    LatLng(location.latitude, location.longitude)
+            androidx.compose.runtime.key(participant.userId) {
+                ParticipantMapMarker(
+                    participant = participant,
+                    uiParticipants = uiParticipants,
+                    pagerState = pagerState,
+                    cameraPositionState = cameraPositionState
                 )
-
-                screenPosition?.let { screenPos ->
-                    val isSelected = uiParticipants.getOrNull(pagerState.currentPage)?.name == participant.name
-
-                    // 참가자 색상 찾기
-                    val participantColor = uiParticipants.find { it.name == participant.name }?.color
-                        ?: Color(0xFFE53935)
-
-                    // px를 dp로 변환
-                    val density = androidx.compose.ui.platform.LocalDensity.current
-                    val offsetX = with(density) { (screenPos.x - 28f).toDp() }
-                    val offsetY = with(density) { (screenPos.y - 28f).toDp() }
-
-                    Box(
-                        modifier = Modifier
-                            .offset(x = offsetX, y = offsetY)
-                            .size(56.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        // 심장 박동 동심원 애니메이션 (선택된 경우만)
-                        if (isSelected) {
-                            val infiniteTransition = rememberInfiniteTransition(label = "mapPulse_${participant.userId}")
-                            val pulseScale by infiniteTransition.animateFloat(
-                                initialValue = 1f,
-                                targetValue = 1.5f,
-                                animationSpec = infiniteRepeatable(
-                                    animation = tween(1000)
-                                ),
-                                label = "mapPulseScale"
-                            )
-                            val pulseAlpha by infiniteTransition.animateFloat(
-                                initialValue = 0.6f,
-                                targetValue = 0f,
-                                animationSpec = infiniteRepeatable(
-                                    animation = tween(1000)
-                                ),
-                                label = "mapPulseAlpha"
-                            )
-
-                            Box(
-                                modifier = Modifier
-                                    .size(40.dp * pulseScale)
-                                    .clip(CircleShape)
-                                    .background(participantColor.copy(alpha = pulseAlpha))
-                            )
-                        }
-
-                        // 메인 마커
-                        Box(
-                            modifier = Modifier
-                                .size(40.dp)
-                                .clip(CircleShape)
-                                .background(participantColor)
-                                .border(2.dp, Color.White, CircleShape),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Person,
-                                contentDescription = participant.name,
-                                tint = Color.White,
-                                modifier = Modifier.size(28.dp)
-                            )
-                        }
-                    }
-                }
             }
         }
 
@@ -579,8 +448,290 @@ private fun MapScreen(
     if (showInviteDialog) {
         InviteDialog(
             inviteCode = roomId,
-            onDismiss = { showInviteDialog = false }
+            onDismiss = { onAction(MapIntent.DismissInviteDialog) }
         )
+    }
+}
+
+/**
+ * 참가자 트래킹바 컴포넌트
+ * 목적지를 기준으로 참가자들의 거리를 시각화
+ * 펄스 애니메이션이 바 영역을 넘어설 수 있도록 레이어 분리
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ParticipantTrackingBar(
+    participants: List<com.teammanduk.adego.core.model.Participant>,
+    uiParticipants: List<Participant>,
+    destination: com.teammanduk.adego.core.model.Place?,
+    pagerState: androidx.compose.foundation.pager.PagerState,
+    onParticipantClick: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // 외부 Box: 클리핑 없이 펄스 효과가 넘칠 수 있도록
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp) // 펄스가 넘칠 공간 확보
+    ) {
+        // 배경 바 (클리핑됨)
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(40.dp)
+                .align(Alignment.Center)
+                .background(
+                    color = Color(0xFFD6E9F5),
+                    shape = RoundedCornerShape(32.dp)
+                )
+                .padding(horizontal = 12.dp)
+        ) {
+            val barWidth = maxWidth - 24.dp // padding 제외한 실제 트래킹바 너비
+
+            // 약속장소 아이콘 (왼쪽 끝, 0%)
+            destination?.let {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(AdegoTheme.colors.main500),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.LocationOn,
+                        contentDescription = "약속장소",
+                        tint = Color.White,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+        }
+
+        // 참가자 아이콘들 (펄스 효과 포함, 클리핑되지 않도록 별도 레이어)
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp) // 전체 높이 사용
+                .align(Alignment.Center)
+                .padding(horizontal = 12.dp)
+        ) {
+            val barWidth = maxWidth - 24.dp
+
+            // 거리 정보가 있는 참가자들로 필터링
+            val participantsWithDistance =
+                participants.filter { it.distanceToDestination != null }
+            val currentMaxDistance =
+                participantsWithDistance.maxOfOrNull { it.distanceToDestination!! } ?: 1000
+
+            // 최대 거리 기록
+            var maxRecordedDistance by remember { mutableStateOf(1000) }
+            if (currentMaxDistance > maxRecordedDistance) {
+                maxRecordedDistance = currentMaxDistance
+            }
+
+            val trackerMaxDistance = maxRecordedDistance.coerceAtLeast(1000)
+
+            participantsWithDistance.forEach { participant ->
+                val uiParticipant = uiParticipants.find { it.name == participant.name }
+
+                uiParticipant?.let { uiPart ->
+                    val index = uiParticipants.indexOf(uiPart)
+                    val isSelected = pagerState.currentPage == index
+
+                    val iconSize by animateDpAsState(
+                        targetValue = if (isSelected) 32.dp else 28.dp,
+                        animationSpec = spring(
+                            dampingRatio = 0.7f,
+                            stiffness = 200f
+                        ),
+                        label = "iconSize"
+                    )
+
+                    // normalizedPosition: 실제 거리를 트래커 최대 거리로 나눔
+                    val normalizedPosition = if (trackerMaxDistance > 0) {
+                        (participant.distanceToDestination!!.toFloat() / trackerMaxDistance.toFloat()).coerceIn(
+                            0f,
+                            1f
+                        )
+                    } else {
+                        0f
+                    }
+
+                    // 실제 offset 계산
+                    val offsetX = 36.dp + (barWidth - 72.dp) * normalizedPosition
+
+                    Box(
+                        modifier = Modifier
+                            .offset(x = offsetX, y = 0.dp)
+                            .size(56.dp) // 펄스가 확장될 공간
+                            .align(Alignment.CenterStart)
+                            .zIndex(if (isSelected) 1f else 0f), // 선택된 아이콘을 최상단에 표시
+                        contentAlignment = Alignment.Center
+                    ) {
+                        // 펄스 애니메이션 (선택된 경우만, 뒤에 배치)
+                        if (isSelected) {
+                            val infiniteTransition =
+                                rememberInfiniteTransition(label = "pulse_${uiPart.name}")
+                            val pulseScale by infiniteTransition.animateFloat(
+                                initialValue = 1f,
+                                targetValue = 2.0f,
+                                animationSpec = infiniteRepeatable(
+                                    animation = tween(1000)
+                                ),
+                                label = "pulseScale"
+                            )
+                            val pulseAlpha by infiniteTransition.animateFloat(
+                                initialValue = 0.5f,
+                                targetValue = 0f,
+                                animationSpec = infiniteRepeatable(
+                                    animation = tween(1000)
+                                ),
+                                label = "pulseAlpha"
+                            )
+
+                            Box(
+                                modifier = Modifier
+                                    .size(iconSize * pulseScale)
+                                    .background(
+                                        color = uiPart.color.copy(alpha = pulseAlpha),
+                                        shape = CircleShape
+                                    )
+                            )
+                        }
+
+                        // 메인 아이콘 (앞에 배치)
+                        Box(
+                            modifier = Modifier
+                                .size(iconSize)
+                                .clip(CircleShape)
+                                .background(Color.White)
+                                .border(2.dp, Color.White, CircleShape)
+                                .padding(2.dp)
+                                .clip(CircleShape)
+                                .background(uiPart.color)
+                                .clickable { onParticipantClick(index) },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Person,
+                                contentDescription = uiPart.name,
+                                tint = Color.White,
+                                modifier = Modifier.size(if (isSelected) 18.dp else 16.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 화면 밖에 있는 참가자를 표시하는 마커 컴포넌트
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ParticipantMapMarker(
+    participant: com.teammanduk.adego.core.model.Participant,
+    uiParticipants: List<Participant>,
+    pagerState: androidx.compose.foundation.pager.PagerState,
+    cameraPositionState: com.google.maps.android.compose.CameraPositionState
+) {
+    participant.location?.let { location ->
+        // 카메라 position이 변경될 때마다 리컴포지션
+        val cameraPosition = cameraPositionState.position
+
+        // projection 계산을 derivedStateOf로 최적화
+        val screenPosition by androidx.compose.runtime.derivedStateOf {
+            cameraPositionState.projection?.toScreenLocation(
+                LatLng(location.latitude, location.longitude)
+            )
+        }
+
+        // 화면 크기 가져오기
+        val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+        val screenWidthPx = with(androidx.compose.ui.platform.LocalDensity.current) {
+            configuration.screenWidthDp.dp.toPx()
+        }
+        val screenHeightPx = with(androidx.compose.ui.platform.LocalDensity.current) {
+            configuration.screenHeightDp.dp.toPx()
+        }
+
+        // 화면 안/밖 판단
+        val isOnScreen = screenPosition?.let { pos ->
+            pos.x >= 0f && pos.x <= screenWidthPx && pos.y >= 0f && pos.y <= screenHeightPx
+        } ?: false
+
+        // 화면 밖인 경우만 오버레이로 표시 (나중에 화살표로 변경 예정)
+        if (!isOnScreen) {
+            screenPosition?.let { screenPos ->
+                val isSelected =
+                    uiParticipants.getOrNull(pagerState.currentPage)?.name == participant.name
+
+                // 참가자 색상 찾기
+                val participantColor = uiParticipants.find { it.name == participant.name }?.color
+                    ?: Color(0xFFE53935)
+
+                // px를 dp로 변환
+                val density = androidx.compose.ui.platform.LocalDensity.current
+                val offsetX = with(density) { (screenPos.x - 28f).toDp() }
+                val offsetY = with(density) { (screenPos.y - 28f).toDp() }
+
+                Box(
+                    modifier = Modifier
+                        .offset(x = offsetX, y = offsetY)
+                        .size(56.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    // 심장 박동 동심원 애니메이션 (선택된 경우만)
+                    if (isSelected) {
+                        val infiniteTransition =
+                            rememberInfiniteTransition(label = "mapPulse_${participant.userId}")
+                        val pulseScale by infiniteTransition.animateFloat(
+                            initialValue = 1f,
+                            targetValue = 1.5f,
+                            animationSpec = infiniteRepeatable(
+                                animation = tween(1000)
+                            ),
+                            label = "mapPulseScale"
+                        )
+                        val pulseAlpha by infiniteTransition.animateFloat(
+                            initialValue = 0.6f,
+                            targetValue = 0f,
+                            animationSpec = infiniteRepeatable(
+                                animation = tween(1000)
+                            ),
+                            label = "mapPulseAlpha"
+                        )
+
+                        Box(
+                            modifier = Modifier
+                                .size(40.dp * pulseScale)
+                                .clip(CircleShape)
+                                .background(participantColor.copy(alpha = pulseAlpha))
+                        )
+                    }
+
+                    // 메인 마커
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(participantColor)
+                            .border(2.dp, Color.White, CircleShape),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Person,
+                            contentDescription = participant.name,
+                            tint = Color.White,
+                            modifier = Modifier.size(28.dp)
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -826,15 +977,64 @@ private fun InviteDialog(
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 private fun MapScreenPreview() {
+    // 더미 참가자 데이터 (테스트용)
+    val dummyParticipants = listOf(
+        com.teammanduk.adego.core.model.Participant(
+            userId = "user1",
+            name = "김철수",
+            profileColor = "#E53935",
+            location = com.teammanduk.adego.core.model.ParticipantLocation(
+                latitude = 37.5665,
+                longitude = 126.9780,
+                updatedAt = System.currentTimeMillis()
+            ),
+            distanceToDestination = 1500,
+            route = null
+        ),
+        com.teammanduk.adego.core.model.Participant(
+            userId = "user2",
+            name = "이영희",
+            profileColor = "#43A047",
+            location = com.teammanduk.adego.core.model.ParticipantLocation(
+                latitude = 37.5675,
+                longitude = 126.9790,
+                updatedAt = System.currentTimeMillis()
+            ),
+            distanceToDestination = 800,
+            route = null
+        ),
+        com.teammanduk.adego.core.model.Participant(
+            userId = "user3",
+            name = "박민수",
+            profileColor = "#1E88E5",
+            location = com.teammanduk.adego.core.model.ParticipantLocation(
+                latitude = 37.5655,
+                longitude = 126.9770,
+                updatedAt = System.currentTimeMillis()
+            ),
+            distanceToDestination = 2000,
+            route = null
+        )
+    )
+
+    val dummyDestination = com.teammanduk.adego.core.model.Place(
+        name = "스타벅스 명동점",
+        address = "서울시 중구 명동",
+        latitude = 37.5665,
+        longitude = 126.9780
+    )
+
     AdegoTheme {
         MapScreen(
             roomId = "preview123",
             meetingTime = "14시 30분",
-            participants = emptyList(),
+            participants = dummyParticipants,
             selectedParticipantIndex = 0,
-            onParticipantSelected = {},
-            destination = null,
-            currentUserId = "preview_user"
+            onAction = {},
+            destination = dummyDestination,
+            currentUserId = "user1",
+            initialLocation = dummyParticipants[0].location!!,
+            showInviteDialog = false
         )
     }
 }

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Button
@@ -92,6 +93,7 @@ internal fun MapRoute(
     val participants by viewModel.participants.collectAsState()
     val selectedParticipantIndex by viewModel.selectedParticipantIndex.collectAsState()
     val isInitialLocationLoaded by viewModel.isInitialLocationLoaded.collectAsState()
+    val participantDistances by viewModel.participantDistances.collectAsState()
 
     // 위치 권한 요청
     val locationPermissionLauncher = rememberLauncherForActivityResult(
@@ -126,6 +128,7 @@ internal fun MapRoute(
             roomId = roomId,
             meetingTime = meetingTime,
             participants = participants,
+            participantDistances = participantDistances,
             selectedParticipantIndex = selectedParticipantIndex,
             onParticipantSelected = viewModel::onParticipantSelected,
             destination = room?.destination,
@@ -167,6 +170,7 @@ private fun MapScreen(
     roomId: String,
     meetingTime: String,
     participants: List<com.teammanduk.adego.core.model.Participant>,
+    participantDistances: List<ParticipantDistance>,
     selectedParticipantIndex: Int,
     onParticipantSelected: (Int) -> Unit,
     destination: com.teammanduk.adego.core.model.Place?,
@@ -341,77 +345,111 @@ private fun MapScreen(
                 }
             }
 
-            // 참가자 아이콘 바
-            Row(
+            // 참가자 트래킹 바 (거리 기반 배치)
+            BoxWithConstraints(
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(
                         color = Color(0xFFD6E9F5),
                         shape = RoundedCornerShape(32.dp)
                     )
-                    .padding(horizontal = 12.dp, vertical = 4.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                    .padding(horizontal = 12.dp, vertical = 4.dp)
+                    .height(56.dp)
             ) {
-                uiParticipants.forEachIndexed { index, participant ->
-                    val isSelected = pagerState.currentPage == index
-                    val iconSize by animateDpAsState(
-                        targetValue = if (isSelected) 40.dp else 32.dp,
-                        animationSpec = spring(
-                            dampingRatio = 0.7f,
-                            stiffness = 200f
-                        ),
-                        label = "iconSize"
-                    )
+                val barWidth = maxWidth - 24.dp // padding 제외한 실제 트래킹바 너비
 
+                // 약속장소 아이콘 (왼쪽 끝, 0%)
+                destination?.let {
                     Box(
                         modifier = Modifier
-                            .weight(1f)
-                            .height(56.dp),
+                            .align(Alignment.CenterStart)
+                            .size(32.dp)
+                            .clip(CircleShape)
+                            .background(AdegoTheme.colors.main500),
                         contentAlignment = Alignment.Center
                     ) {
-                        // 심장 박동 동심원 애니메이션 (선택된 경우만)
-                        if (isSelected) {
-                            val infiniteTransition = rememberInfiniteTransition(label = "pulse")
-                            val pulseScale by infiniteTransition.animateFloat(
-                                initialValue = 1f,
-                                targetValue = 1.4f,
-                                animationSpec = infiniteRepeatable(
-                                    animation = tween(1000)
-                                ),
-                                label = "pulseScale"
-                            )
-                            val pulseAlpha by infiniteTransition.animateFloat(
-                                initialValue = 0.6f,
-                                targetValue = 0f,
-                                animationSpec = infiniteRepeatable(
-                                    animation = tween(1000)
-                                ),
-                                label = "pulseAlpha"
-                            )
+                        Icon(
+                            imageVector = Icons.Default.LocationOn,
+                            contentDescription = "약속장소",
+                            tint = Color.White,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
 
-                            Box(
-                                modifier = Modifier
-                                    .size(iconSize * pulseScale)
-                                    .clip(CircleShape)
-                                    .background(participant.color.copy(alpha = pulseAlpha))
-                            )
-                        }
+                // 참가자 아이콘들 (거리 기반 위치)
+                participantDistances.forEach { participantDistance ->
+                    val participant = uiParticipants.find {
+                        it.name == participantDistance.participant.name
+                    }
 
-                        // 메인 아이콘
+                    participant?.let { uiParticipant ->
+                        val index = uiParticipants.indexOf(uiParticipant)
+                        val isSelected = pagerState.currentPage == index
+
+                        val iconSize by animateDpAsState(
+                            targetValue = if (isSelected) 40.dp else 32.dp,
+                            animationSpec = spring(
+                                dampingRatio = 0.7f,
+                                stiffness = 200f
+                            ),
+                            label = "iconSize"
+                        )
+
+                        // normalizedPosition: 0.0f (약속장소) ~ 1.0f (가장 먼 곳)
+                        // 실제 offset 계산: 약속장소 아이콘 너비(32dp) + 여백(8dp) + 비율에 따른 위치
+                        val offsetX = 40.dp + (barWidth - 80.dp) * participantDistance.normalizedPosition
+
                         Box(
                             modifier = Modifier
+                                .offset(x = offsetX, y = 0.dp)
                                 .size(iconSize)
-                                .clip(CircleShape)
-                                .background(participant.color),
+                                .align(Alignment.CenterStart),
                             contentAlignment = Alignment.Center
                         ) {
-                            Icon(
-                                imageVector = Icons.Default.Person,
-                                contentDescription = participant.name,
-                                tint = Color.White,
-                                modifier = Modifier.size(if (isSelected) 24.dp else 20.dp)
-                            )
+                            // 심장 박동 동심원 애니메이션 (선택된 경우만)
+                            if (isSelected) {
+                                val infiniteTransition = rememberInfiniteTransition(label = "pulse_${uiParticipant.name}")
+                                val pulseScale by infiniteTransition.animateFloat(
+                                    initialValue = 1f,
+                                    targetValue = 1.4f,
+                                    animationSpec = infiniteRepeatable(
+                                        animation = tween(1000)
+                                    ),
+                                    label = "pulseScale"
+                                )
+                                val pulseAlpha by infiniteTransition.animateFloat(
+                                    initialValue = 0.6f,
+                                    targetValue = 0f,
+                                    animationSpec = infiniteRepeatable(
+                                        animation = tween(1000)
+                                    ),
+                                    label = "pulseAlpha"
+                                )
+
+                                Box(
+                                    modifier = Modifier
+                                        .size(iconSize * pulseScale)
+                                        .clip(CircleShape)
+                                        .background(uiParticipant.color.copy(alpha = pulseAlpha))
+                                )
+                            }
+
+                            // 메인 아이콘
+                            Box(
+                                modifier = Modifier
+                                    .size(iconSize)
+                                    .clip(CircleShape)
+                                    .background(uiParticipant.color),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Person,
+                                    contentDescription = uiParticipant.name,
+                                    tint = Color.White,
+                                    modifier = Modifier.size(if (isSelected) 24.dp else 20.dp)
+                                )
+                            }
                         }
                     }
                 }
@@ -788,6 +826,7 @@ private fun MapScreenPreview() {
             roomId = "preview123",
             meetingTime = "14시 30분",
             participants = emptyList(),
+            participantDistances = emptyList(),
             selectedParticipantIndex = 0,
             onParticipantSelected = {},
             destination = null,

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
@@ -33,16 +34,21 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Create
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import android.Manifest
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -63,8 +69,6 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapUiSettings
-import com.google.maps.android.compose.Marker
-import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
 import kotlinx.coroutines.launch
@@ -80,32 +84,174 @@ private data class Participant(
 
 @Composable
 internal fun MapRoute(
+    roomId: String,
     meetingTime: String = "00시 00분",
+    viewModel: MapViewModel,
 ) {
-    MapScreen(
-        meetingTime = meetingTime
-    )
+    val room by viewModel.room.collectAsState()
+    val participants by viewModel.participants.collectAsState()
+    val selectedParticipantIndex by viewModel.selectedParticipantIndex.collectAsState()
+    val isInitialLocationLoaded by viewModel.isInitialLocationLoaded.collectAsState()
+
+    // 위치 권한 요청
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val granted = permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+                permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        if (granted) {
+            android.util.Log.d("A-degoLogTag", "[MapScreen] 위치 권한 승인됨 - 위치 추적 시작")
+            viewModel.startLocationTracking()
+        } else {
+            android.util.Log.w("A-degoLogTag", "[MapScreen] 위치 권한 거부됨")
+        }
+    }
+
+    // 화면 진입 시 권한 요청
+    LaunchedEffect(Unit) {
+        android.util.Log.d("A-degoLogTag", "[MapScreen] 위치 권한 요청 시작")
+        locationPermissionLauncher.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        )
+    }
+
+    // 초기 위치를 로드할 때까지 로딩 화면 표시
+    if (!isInitialLocationLoaded) {
+        LoadingScreen()
+    } else {
+        MapScreen(
+            roomId = roomId,
+            meetingTime = meetingTime,
+            participants = participants,
+            selectedParticipantIndex = selectedParticipantIndex,
+            onParticipantSelected = viewModel::onParticipantSelected,
+            destination = room?.destination,
+            currentUserId = viewModel.userId
+        )
+    }
+}
+
+@Composable
+private fun LoadingScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+            .background(Color.White),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(48.dp),
+                color = AdegoTheme.colors.main500,
+                strokeWidth = 4.dp
+            )
+            Text(
+                text = "현재 위치를 가져오는 중...",
+                style = AdegoTheme.typography.bodyLarge,
+                color = AdegoTheme.colors.onBackground
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun MapScreen(
-    meetingTime: String
+    roomId: String,
+    meetingTime: String,
+    participants: List<com.teammanduk.adego.core.model.Participant>,
+    selectedParticipantIndex: Int,
+    onParticipantSelected: (Int) -> Unit,
+    destination: com.teammanduk.adego.core.model.Place?,
+    currentUserId: String
 ) {
-    // 임시 참가자 데이터
-    val participants = remember {
-        listOf(
-            Participant("홍길동", 0, "잠시 후 도착", Color(0xFFE53935)),
-            Participant("김철수", 300, "도착중", Color(0xFF5C6BC0)),
-            Participant("이영희", 500, "도착중", Color(0xFF43A047)),
-            Participant("박민수", 800, "도착중", Color(0xFFD81B60)),
-            Participant("최영수", 1200, "도착중", Color(0xFF00ACC1))
-        )
+    // 임시: UI 전용 Participant 데이터로 변환
+    val uiParticipants = remember(participants) {
+        participants.mapIndexed { index, participant ->
+            // profileColor가 비어있거나 유효하지 않으면 기본 색상 사용
+            val parsedColor = try {
+                if (participant.profileColor.isNotEmpty()) {
+                    Color(android.graphics.Color.parseColor(participant.profileColor))
+                } else {
+                    Color(0xFFE53935) // 기본 빨강
+                }
+            } catch (e: Exception) {
+                android.util.Log.w("A-degoLogTag", "[MapScreen] profileColor 파싱 실패: ${participant.profileColor}, 기본 색상 사용")
+                Color(0xFFE53935) // 기본 빨강
+            }
+
+            Participant(
+                name = participant.name,
+                distanceInMeters = participant.route?.distanceInMeters ?: 0,
+                status = if (participant.route?.eta != null) "도착중" else "대기중",
+                color = parsedColor
+            )
+        }
     }
 
-    val pagerState = rememberPagerState(pageCount = { participants.size })
+    val pagerState = rememberPagerState(
+        pageCount = { uiParticipants.size },
+        initialPage = selectedParticipantIndex
+    )
     val coroutineScope = rememberCoroutineScope()
     var showInviteDialog by remember { mutableStateOf(false) }
+
+    // 현재 사용자 찾기
+    val currentUser = remember(participants, currentUserId) {
+        participants.find { it.userId == currentUserId }
+    }
+
+    // 초기 렌더링 여부 추적
+    var isInitialRender by remember { mutableStateOf(true) }
+
+    // 지도 카메라 위치 설정 - 현재 사용자 위치가 반드시 있어야 함
+    val cameraPositionState = rememberCameraPositionState {
+        currentUser?.location?.let { location ->
+            android.util.Log.d("A-degoLogTag", "[MapScreen] 카메라 초기화: 현재 사용자 위치 lat=${location.latitude}, lng=${location.longitude}")
+            position = CameraPosition.fromLatLngZoom(
+                LatLng(location.latitude, location.longitude),
+                15f
+            )
+        } ?: run {
+            // 이 경우는 발생하면 안 됨 (로딩 화면에서 위치를 받은 후에만 여기 도달)
+            android.util.Log.w("A-degoLogTag", "[MapScreen] 경고: 현재 사용자 위치가 없음")
+            position = CameraPosition.fromLatLngZoom(LatLng(37.5665, 126.9780), 15f)
+        }
+    }
+
+    // 현재 사용자의 위치가 업데이트되면 카메라 이동 (초기 렌더링은 제외)
+    LaunchedEffect(currentUser?.location) {
+        currentUser?.location?.let { location ->
+            if (isInitialRender) {
+                // 초기 렌더링: 애니메이션 없이 바로 이동
+                android.util.Log.d("A-degoLogTag", "[MapScreen] 초기 카메라 위치 설정: lat=${location.latitude}, lng=${location.longitude}")
+                cameraPositionState.move(
+                    com.google.android.gms.maps.CameraUpdateFactory.newLatLngZoom(
+                        LatLng(location.latitude, location.longitude),
+                        15f
+                    )
+                )
+                isInitialRender = false
+            } else {
+                // 이후 업데이트: 부드럽게 애니메이션
+                android.util.Log.d("A-degoLogTag", "[MapScreen] 현재 사용자 위치 업데이트: lat=${location.latitude}, lng=${location.longitude}")
+                cameraPositionState.animate(
+                    com.google.android.gms.maps.CameraUpdateFactory.newLatLngZoom(
+                        LatLng(location.latitude, location.longitude),
+                        15f
+                    ),
+                    durationMs = 1000
+                )
+            }
+        }
+    }
 
     Box(
         modifier = Modifier
@@ -113,7 +259,30 @@ private fun MapScreen(
             .systemBarsPadding()
     ) {
         // 전체 화면 지도
-        MapPlaceholder(modifier = Modifier.fillMaxSize())
+        GoogleMap(
+            modifier = Modifier.fillMaxSize(),
+            cameraPositionState = cameraPositionState,
+            properties = MapProperties(
+                isMyLocationEnabled = false
+            ),
+            uiSettings = MapUiSettings(
+                zoomControlsEnabled = false,
+                myLocationButtonEnabled = false,
+                compassEnabled = false,
+                mapToolbarEnabled = false
+            )
+        ) {
+            // 목적지 마커 추가
+            destination?.let {
+                com.google.maps.android.compose.Marker(
+                    state = com.google.maps.android.compose.rememberMarkerState(
+                        position = LatLng(it.latitude, it.longitude)
+                    ),
+                    title = it.name,
+                    snippet = "목적지"
+                )
+            }
+        }
 
         // 상단 영역
         Column(
@@ -149,7 +318,7 @@ private fun MapScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = "모임인원: ${participants.size}명",
+                        text = "모임인원: ${uiParticipants.size}명",
                         style = AdegoTheme.typography.bodyLarge,
                         color = AdegoTheme.colors.highlight500
                     )
@@ -184,7 +353,7 @@ private fun MapScreen(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                participants.forEachIndexed { index, participant ->
+                uiParticipants.forEachIndexed { index, participant ->
                     val isSelected = pagerState.currentPage == index
                     val iconSize by animateDpAsState(
                         targetValue = if (isSelected) 40.dp else 32.dp,
@@ -249,169 +418,36 @@ private fun MapScreen(
             }
         }
 
-        // 하단 참가자 카드 (스와이프)
-        Box(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .padding(bottom = 16.dp)
-        ) {
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier.fillMaxWidth(),
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 32.dp),
-                pageSpacing = 16.dp
-            ) { page ->
-                ParticipantCard(
-                    participant = participants[page],
-                    currentPage = pagerState.currentPage,
-                    totalPages = participants.size,
-                    onPreviousClick = {
-                        coroutineScope.launch {
-                            if (pagerState.currentPage > 0) {
-                                pagerState.animateScrollToPage(pagerState.currentPage - 1)
-                            }
-                        }
-                    },
-                    onNextClick = {
-                        coroutineScope.launch {
-                            if (pagerState.currentPage < participants.size - 1) {
-                                pagerState.animateScrollToPage(pagerState.currentPage + 1)
-                            }
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth()
+        // 지도 위 참가자 위치 마커들
+        participants.forEach { participant ->
+            participant.location?.let { location ->
+                // 위도/경도를 화면 좌표로 변환
+                val projection = cameraPositionState.projection
+                val screenPosition = projection?.toScreenLocation(
+                    LatLng(location.latitude, location.longitude)
                 )
-            }
-        }
 
-        // 지도 위 참가자 위치 마커들 (상단/하단 패딩으로 영역 제한)
-        BoxWithConstraints(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = 200.dp, bottom = 240.dp)  // 상단 섹션과 하단 카드 영역 제외
-        ) {
-            val screenWidth = maxWidth
-            val screenHeight = maxHeight
+                screenPosition?.let { screenPos ->
+                    val isSelected = uiParticipants.getOrNull(pagerState.currentPage)?.name == participant.name
 
-            participants.forEachIndexed { index, participant ->
-                // TODO: 실제 위치 데이터로 대체 필요
-                // 임시로 위치 표시 (일부는 화면 밖, 다양한 방향으로 분산)
-                val offsetX = when (participant.name) {
-                    "홍길동" -> screenWidth / 2  // 화면 내
-                    "김철수" -> screenWidth + 100.dp  // 화면 밖 (오른쪽)
-                    "이영희" -> screenWidth / 2  // 화면 밖 (아래)
-                    "박민수" -> -100.dp  // 화면 밖 (왼쪽)
-                    "최영수" -> screenWidth / 2  // 화면 밖 (위)
-                    else -> 150.dp
-                }
-                val offsetY = when (participant.name) {
-                    "홍길동" -> screenHeight / 2  // 화면 내
-                    "김철수" -> screenHeight / 2  // 화면 밖 (오른쪽)
-                    "이영희" -> screenHeight + 100.dp  // 화면 밖 (아래)
-                    "박민수" -> screenHeight / 2  // 화면 밖 (왼쪽)
-                    "최영수" -> -50.dp  // 화면 밖 (위)
-                    else -> screenHeight / 2
-                }
+                    // 참가자 색상 찾기
+                    val participantColor = uiParticipants.find { it.name == participant.name }?.color
+                        ?: Color(0xFFE53935)
 
-                // 경계값 정의 (dp) - 이제 padding된 영역 내부 기준
-                val topBound = 0.dp
-                val bottomBound = screenHeight
-                val leftBound = 16.dp
-                val rightBound = screenWidth - 80.dp
-
-                val isSelected = pagerState.currentPage == index
-                val isOutOfBounds = offsetX < leftBound || offsetX > rightBound ||
-                        offsetY < topBound || offsetY > bottomBound
-
-                if (isOutOfBounds) {
-                    // 화면 밖 참가자 - 말풍선으로 표시
-                    // 실제 위치를 경계 내로 제한 (말풍선을 표시할 위치)
-                    val edgeX = offsetX.coerceIn(leftBound, rightBound)
-                    val edgeY = offsetY.coerceIn(topBound, bottomBound)
-
-                    // 말풍선 위치에서 실제 위치로의 방향 (꼬리 방향)
-                    val dx = (offsetX - edgeX).value
-                    val dy = (offsetY - edgeY).value
-                    val angle = atan2(dy, dx)
+                    // px를 dp로 변환
+                    val density = androidx.compose.ui.platform.LocalDensity.current
+                    val offsetX = with(density) { (screenPos.x - 28f).toDp() }
+                    val offsetY = with(density) { (screenPos.y - 28f).toDp() }
 
                     Box(
                         modifier = Modifier
-                            .padding(start = edgeX, top = edgeY)
-                            .size(48.dp)
-                            .align(Alignment.TopStart)
-                            .drawBehind {
-                                // 원형 배경
-                                drawCircle(
-                                    color = participant.color,
-                                    radius = 20.dp.toPx(),
-                                    center = center
-                                )
-
-                                // 말풍선 꼬리 (삼각형)
-                                val tailSize = 10.dp.toPx()
-                                val circleRadius = 20.dp.toPx()
-
-                                // 각도에 따른 꼬리 시작점 계산
-                                val tailBaseX = center.x + kotlin.math.cos(angle) * circleRadius
-                                val tailBaseY = center.y + kotlin.math.sin(angle) * circleRadius
-                                val tailTipX = tailBaseX + kotlin.math.cos(angle) * tailSize
-                                val tailTipY = tailBaseY + kotlin.math.sin(angle) * tailSize
-
-                                // 삼각형 양 옆 점 계산
-                                val perpAngle1 = angle + Math.PI / 2
-                                val perpAngle2 = angle - Math.PI / 2
-                                val baseOffset = 6.dp.toPx()
-
-                                val point1X = tailBaseX + kotlin.math.cos(perpAngle1) * baseOffset
-                                val point1Y = tailBaseY + kotlin.math.sin(perpAngle1) * baseOffset
-                                val point2X = tailBaseX + kotlin.math.cos(perpAngle2) * baseOffset
-                                val point2Y = tailBaseY + kotlin.math.sin(perpAngle2) * baseOffset
-
-                                val tailPath = Path().apply {
-                                    moveTo(point1X.toFloat(), point1Y.toFloat())
-                                    lineTo(tailTipX.toFloat(), tailTipY.toFloat())
-                                    lineTo(point2X.toFloat(), point2Y.toFloat())
-                                    close()
-                                }
-                                drawPath(tailPath, participant.color)
-
-                                // 흰색 테두리 - 원
-                                drawCircle(
-                                    color = androidx.compose.ui.graphics.Color.White,
-                                    radius = 20.dp.toPx(),
-                                    center = center,
-                                    style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2.dp.toPx())
-                                )
-
-                                // 흰색 테두리 - 꼬리
-                                drawPath(
-                                    tailPath,
-                                    color = androidx.compose.ui.graphics.Color.White,
-                                    style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2.dp.toPx())
-                                )
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Person,
-                            contentDescription = participant.name,
-                            tint = Color.White,
-                            modifier = Modifier.size(24.dp)
-                        )
-                    }
-                } else {
-                    // 화면 내 참가자 - 일반 마커
-                    Box(
-                        modifier = Modifier
-                            .padding(start = offsetX, top = offsetY)
-                            .size(56.dp)
-                            .align(Alignment.TopStart),
+                            .offset(x = offsetX, y = offsetY)
+                            .size(56.dp),
                         contentAlignment = Alignment.Center
                     ) {
                         // 심장 박동 동심원 애니메이션 (선택된 경우만)
                         if (isSelected) {
-                            val infiniteTransition = rememberInfiniteTransition(label = "mapPulse")
+                            val infiniteTransition = rememberInfiniteTransition(label = "mapPulse_${participant.userId}")
                             val pulseScale by infiniteTransition.animateFloat(
                                 initialValue = 1f,
                                 targetValue = 1.5f,
@@ -433,7 +469,7 @@ private fun MapScreen(
                                 modifier = Modifier
                                     .size(40.dp * pulseScale)
                                     .clip(CircleShape)
-                                    .background(participant.color.copy(alpha = pulseAlpha))
+                                    .background(participantColor.copy(alpha = pulseAlpha))
                             )
                         }
 
@@ -442,7 +478,8 @@ private fun MapScreen(
                             modifier = Modifier
                                 .size(40.dp)
                                 .clip(CircleShape)
-                                .background(participant.color),
+                                .background(participantColor)
+                                .border(2.dp, Color.White, CircleShape),
                             contentAlignment = Alignment.Center
                         ) {
                             Icon(
@@ -456,39 +493,51 @@ private fun MapScreen(
                 }
             }
         }
+
+        // 하단 참가자 카드 (스와이프)
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .padding(bottom = 16.dp)
+        ) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxWidth(),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 32.dp),
+                pageSpacing = 16.dp
+            ) { page ->
+                ParticipantCard(
+                    participant = uiParticipants[page],
+                    currentPage = pagerState.currentPage,
+                    totalPages = uiParticipants.size,
+                    onPreviousClick = {
+                        coroutineScope.launch {
+                            if (pagerState.currentPage > 0) {
+                                pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                            }
+                        }
+                    },
+                    onNextClick = {
+                        coroutineScope.launch {
+                            if (pagerState.currentPage < uiParticipants.size - 1) {
+                                pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                            }
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+
     }
 
     // 초대 다이얼로그
     if (showInviteDialog) {
         InviteDialog(
-            inviteCode = "ABC123",
+            inviteCode = roomId,
             onDismiss = { showInviteDialog = false }
         )
-    }
-}
-
-@Composable
-private fun MapPlaceholder(
-    modifier: Modifier = Modifier
-) {
-    // 서울 강남역 근처 좌표 (기본값)
-    val gangnam = LatLng(37.498095, 127.027610)
-    val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(gangnam, 15f)
-    }
-
-    GoogleMap(
-        modifier = modifier,
-        cameraPositionState = cameraPositionState,
-        properties = MapProperties(
-            isMyLocationEnabled = false
-        ),
-        uiSettings = MapUiSettings(
-            zoomControlsEnabled = false,
-            myLocationButtonEnabled = false
-        )
-    ) {
-        // 마커는 필요시 추가
     }
 }
 
@@ -736,7 +785,13 @@ private fun InviteDialog(
 private fun MapScreenPreview() {
     AdegoTheme {
         MapScreen(
-            meetingTime = "14시 30분"
+            roomId = "preview123",
+            meetingTime = "14시 30분",
+            participants = emptyList(),
+            selectedParticipantIndex = 0,
+            onParticipantSelected = {},
+            destination = null,
+            currentUserId = "preview_user"
         )
     }
 }

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapViewModel.kt
@@ -15,10 +15,24 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+
+/**
+ * 지도 화면의 UI 상태
+ */
+data class MapUiState(
+    val room: Room? = null,
+    val participants: List<Participant> = emptyList(),
+    val selectedParticipantIndex: Int = 0,
+    val isLocationTrackingActive: Boolean = false,
+    val isInitialLocationLoaded: Boolean = false,
+    val error: String? = null,
+    val showInviteDialog: Boolean = false
+)
 
 @HiltViewModel(assistedFactory = MapViewModel.Factory::class)
 class MapViewModel @AssistedInject constructor(
@@ -36,41 +50,24 @@ class MapViewModel @AssistedInject constructor(
         ): MapViewModel
     }
 
-    // 방 정보
-    val room: StateFlow<Room?> = roomRepository.observeRoom(roomId)
-        .catch { emit(null) }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = null
+    // UI 상태 통합
+    private val _uiState = MutableStateFlow(MapUiState())
+    val uiState: StateFlow<MapUiState> = combine(
+        roomRepository.observeRoom(roomId).catch { emit(null) },
+        roomRepository.observeParticipants(roomId).catch { emit(emptyList()) },
+        _uiState
+    ) { room, participants, currentState ->
+        currentState.copy(
+            room = room,
+            participants = participants
         )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = MapUiState()
+    )
 
-    // 참가자 목록
-    val participants: StateFlow<List<Participant>> = roomRepository.observeParticipants(roomId)
-        .catch { emit(emptyList()) }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = emptyList()
-        )
-
-    // 현재 선택된 참가자 인덱스
-    private val _selectedParticipantIndex = MutableStateFlow(0)
-    val selectedParticipantIndex: StateFlow<Int> = _selectedParticipantIndex.asStateFlow()
-
-    // 에러 상태
-    private val _error = MutableStateFlow<String?>(null)
-    val error: StateFlow<String?> = _error.asStateFlow()
-
-    // 위치 추적 활성화 여부
-    private val _isLocationTrackingActive = MutableStateFlow(false)
-    val isLocationTrackingActive: StateFlow<Boolean> = _isLocationTrackingActive.asStateFlow()
-
-    // 초기 위치 로딩 상태
-    private val _isInitialLocationLoaded = MutableStateFlow(false)
-    val isInitialLocationLoaded: StateFlow<Boolean> = _isInitialLocationLoaded.asStateFlow()
-
-    // 위치 추적 시작 (외부에서 호출 가능하도록 public으로 변경)
+    // 위치 추적 시작
     fun startLocationTracking() {
         viewModelScope.launch {
             try {
@@ -78,21 +75,31 @@ class MapViewModel @AssistedInject constructor(
                 locationRepository.observeLocationUpdates()
                     .catch { e ->
                         Log.e(TAG, "[MapViewModel] 위치 추적 실패", e)
-                        _error.value = "위치 추적 실패: ${e.message}"
-                        _isLocationTrackingActive.value = false
+                        _uiState.update { it.copy(
+                            error = "위치 추적 실패: ${e.message}",
+                            isLocationTrackingActive = false
+                        ) }
                     }
                     .collect { location ->
                         Log.d(TAG, "[MapViewModel] 위치 업데이트 수신: lat=${location.latitude}, lng=${location.longitude}")
-                        _isLocationTrackingActive.value = true
-                        if (!_isInitialLocationLoaded.value) {
-                            Log.d(TAG, "[MapViewModel] 초기 위치 로드 완료")
-                            _isInitialLocationLoaded.value = true
+
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                isLocationTrackingActive = true,
+                                isInitialLocationLoaded = if (!currentState.isInitialLocationLoaded) {
+                                    Log.d(TAG, "[MapViewModel] 초기 위치 로드 완료")
+                                    true
+                                } else {
+                                    currentState.isInitialLocationLoaded
+                                }
+                            )
                         }
+
                         updateMyLocation(location)
                     }
             } catch (e: Exception) {
                 Log.e(TAG, "[MapViewModel] 위치 추적 시작 실패", e)
-                _error.value = "위치 추적 시작 실패: ${e.message}"
+                _uiState.update { it.copy(error = "위치 추적 시작 실패: ${e.message}") }
             }
         }
     }
@@ -113,18 +120,47 @@ class MapViewModel @AssistedInject constructor(
             Log.d(TAG, "[MapViewModel] Firebase 위치 업데이트 완료")
         } catch (e: Exception) {
             Log.e(TAG, "[MapViewModel] 위치 업데이트 실패", e)
-            _error.value = "위치 업데이트 실패: ${e.message}"
+            _uiState.update { it.copy(error = "위치 업데이트 실패: ${e.message}") }
         }
     }
 
-    // 선택된 참가자 인덱스 변경
-    fun onParticipantSelected(index: Int) {
-        _selectedParticipantIndex.value = index
+    // MVI 패턴: Intent 처리를 위한 단일 진입점
+    fun onAction(intent: MapIntent) {
+        when (intent) {
+            is MapIntent.SelectParticipant -> {
+                _uiState.update { reduce(it, intent) }
+            }
+            MapIntent.ClearError -> {
+                _uiState.update { reduce(it, intent) }
+            }
+            MapIntent.ShowInviteDialog -> {
+                _uiState.update { reduce(it, intent) }
+            }
+            MapIntent.DismissInviteDialog -> {
+                _uiState.update { reduce(it, intent) }
+            }
+        }
     }
 
-    // 에러 메시지 초기화
+    // MVI 패턴: 순수 함수로 상태 변환 처리
+    private fun reduce(state: MapUiState, intent: MapIntent): MapUiState {
+        return when (intent) {
+            is MapIntent.SelectParticipant -> state.copy(selectedParticipantIndex = intent.index)
+            MapIntent.ClearError -> state.copy(error = null)
+            MapIntent.ShowInviteDialog -> state.copy(showInviteDialog = true)
+            MapIntent.DismissInviteDialog -> state.copy(showInviteDialog = false)
+        }
+    }
+
+    // 하위 호환성을 위한 래퍼 함수들 (추후 제거 예정)
+    @Deprecated("Use onAction(MapIntent.SelectParticipant) instead")
+    fun onParticipantSelected(index: Int) {
+        onAction(MapIntent.SelectParticipant(index))
+    }
+
+    @Deprecated("Use onAction(MapIntent.ClearError) instead")
     fun clearError() {
-        _error.value = null
+        onAction(MapIntent.ClearError)
     }
 
     override fun onCleared() {

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapViewModel.kt
@@ -1,0 +1,136 @@
+package com.teammanduk.adego.feature.map
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.teammanduk.adego.core.domain.repository.LocationRepository
+import com.teammanduk.adego.core.domain.repository.RoomRepository
+import com.teammanduk.adego.core.model.Participant
+import com.teammanduk.adego.core.model.ParticipantLocation
+import com.teammanduk.adego.core.model.Room
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+@HiltViewModel(assistedFactory = MapViewModel.Factory::class)
+class MapViewModel @AssistedInject constructor(
+    @Assisted("roomId") private val roomId: String,
+    @Assisted("userId") val userId: String,  // public으로 변경
+    private val roomRepository: RoomRepository,
+    private val locationRepository: LocationRepository
+) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            @Assisted("roomId") roomId: String,
+            @Assisted("userId") userId: String
+        ): MapViewModel
+    }
+
+    // 방 정보
+    val room: StateFlow<Room?> = roomRepository.observeRoom(roomId)
+        .catch { emit(null) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
+
+    // 참가자 목록
+    val participants: StateFlow<List<Participant>> = roomRepository.observeParticipants(roomId)
+        .catch { emit(emptyList()) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+
+    // 현재 선택된 참가자 인덱스
+    private val _selectedParticipantIndex = MutableStateFlow(0)
+    val selectedParticipantIndex: StateFlow<Int> = _selectedParticipantIndex.asStateFlow()
+
+    // 에러 상태
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    // 위치 추적 활성화 여부
+    private val _isLocationTrackingActive = MutableStateFlow(false)
+    val isLocationTrackingActive: StateFlow<Boolean> = _isLocationTrackingActive.asStateFlow()
+
+    // 초기 위치 로딩 상태
+    private val _isInitialLocationLoaded = MutableStateFlow(false)
+    val isInitialLocationLoaded: StateFlow<Boolean> = _isInitialLocationLoaded.asStateFlow()
+
+    // 위치 추적 시작 (외부에서 호출 가능하도록 public으로 변경)
+    fun startLocationTracking() {
+        viewModelScope.launch {
+            try {
+                Log.d(TAG, "[MapViewModel] 위치 추적 시작 - roomId: $roomId, userId: $userId")
+                locationRepository.observeLocationUpdates()
+                    .catch { e ->
+                        Log.e(TAG, "[MapViewModel] 위치 추적 실패", e)
+                        _error.value = "위치 추적 실패: ${e.message}"
+                        _isLocationTrackingActive.value = false
+                    }
+                    .collect { location ->
+                        Log.d(TAG, "[MapViewModel] 위치 업데이트 수신: lat=${location.latitude}, lng=${location.longitude}")
+                        _isLocationTrackingActive.value = true
+                        if (!_isInitialLocationLoaded.value) {
+                            Log.d(TAG, "[MapViewModel] 초기 위치 로드 완료")
+                            _isInitialLocationLoaded.value = true
+                        }
+                        updateMyLocation(location)
+                    }
+            } catch (e: Exception) {
+                Log.e(TAG, "[MapViewModel] 위치 추적 시작 실패", e)
+                _error.value = "위치 추적 시작 실패: ${e.message}"
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "A-degoLogTag"
+    }
+
+    // 내 위치 Firebase에 업데이트
+    private suspend fun updateMyLocation(location: ParticipantLocation) {
+        try {
+            Log.d(TAG, "[MapViewModel] Firebase에 위치 업데이트 중...")
+            roomRepository.updateMyLocation(
+                roomId = roomId,
+                userId = userId,
+                location = location
+            )
+            Log.d(TAG, "[MapViewModel] Firebase 위치 업데이트 완료")
+        } catch (e: Exception) {
+            Log.e(TAG, "[MapViewModel] 위치 업데이트 실패", e)
+            _error.value = "위치 업데이트 실패: ${e.message}"
+        }
+    }
+
+    // 선택된 참가자 인덱스 변경
+    fun onParticipantSelected(index: Int) {
+        _selectedParticipantIndex.value = index
+    }
+
+    // 에러 메시지 초기화
+    fun clearError() {
+        _error.value = null
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        viewModelScope.launch {
+            locationRepository.stopLocationTracking()
+        }
+    }
+}

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapViewModel.kt
@@ -19,6 +19,22 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * 참가자의 거리 정보
+ * @param participant 참가자 정보
+ * @param distanceInMeters 약속장소까지의 거리 (미터)
+ * @param normalizedPosition 트래킹바 위치 (0.0f = 약속장소, 1.0f = 가장 먼 사람)
+ */
+data class ParticipantDistance(
+    val participant: Participant,
+    val distanceInMeters: Int,
+    val normalizedPosition: Float
+)
 
 @HiltViewModel(assistedFactory = MapViewModel.Factory::class)
 class MapViewModel @AssistedInject constructor(
@@ -69,6 +85,26 @@ class MapViewModel @AssistedInject constructor(
     // 초기 위치 로딩 상태
     private val _isInitialLocationLoaded = MutableStateFlow(false)
     val isInitialLocationLoaded: StateFlow<Boolean> = _isInitialLocationLoaded.asStateFlow()
+
+    // 참가자 거리 정보 (트래킹바용)
+    private val _participantDistances = MutableStateFlow<List<ParticipantDistance>>(emptyList())
+    val participantDistances: StateFlow<List<ParticipantDistance>> = _participantDistances.asStateFlow()
+
+    init {
+        // 방 정보와 참가자 정보가 변경될 때마다 거리 계산
+        viewModelScope.launch {
+            kotlinx.coroutines.flow.combine(room, participants) { r, p ->
+                Pair(r, p)
+            }.collect { (currentRoom, currentParticipants) ->
+                currentRoom?.destination?.let { destination ->
+                    _participantDistances.value = calculateParticipantDistances(
+                        participants = currentParticipants,
+                        destination = destination
+                    )
+                }
+            }
+        }
+    }
 
     // 위치 추적 시작 (외부에서 호출 가능하도록 public으로 변경)
     fun startLocationTracking() {
@@ -125,6 +161,79 @@ class MapViewModel @AssistedInject constructor(
     // 에러 메시지 초기화
     fun clearError() {
         _error.value = null
+    }
+
+    /**
+     * 참가자들의 약속장소까지 거리 계산
+     * TODO: 나중에 route 정보가 있으면 경로 기반 거리로 변경
+     */
+    private fun calculateParticipantDistances(
+        participants: List<Participant>,
+        destination: com.teammanduk.adego.core.model.Place
+    ): List<ParticipantDistance> {
+        // 위치 정보가 있는 참가자만 필터링
+        val participantsWithLocation = participants.filter { it.location != null }
+
+        if (participantsWithLocation.isEmpty()) {
+            return emptyList()
+        }
+
+        // 각 참가자의 거리 계산
+        val distances = participantsWithLocation.map { participant ->
+            val location = participant.location!!
+
+            // TODO: route 정보가 있으면 route.distanceInMeters 사용
+            // 현재는 직선 거리 계산 (Haversine)
+            val distanceInMeters = calculateHaversineDistance(
+                lat1 = location.latitude,
+                lon1 = location.longitude,
+                lat2 = destination.latitude,
+                lon2 = destination.longitude
+            )
+
+            ParticipantDistance(
+                participant = participant,
+                distanceInMeters = distanceInMeters,
+                normalizedPosition = 0f // 아래에서 계산
+            )
+        }
+
+        // 가장 먼 거리 찾기
+        val maxDistance = distances.maxOfOrNull { it.distanceInMeters } ?: 1
+
+        // normalized position 계산 (0.0f ~ 1.0f)
+        return distances.map { distance ->
+            distance.copy(
+                normalizedPosition = if (maxDistance > 0) {
+                    distance.distanceInMeters.toFloat() / maxDistance.toFloat()
+                } else {
+                    0f
+                }
+            )
+        }
+    }
+
+    /**
+     * Haversine 공식을 사용한 두 지점 간 직선 거리 계산 (미터)
+     */
+    private fun calculateHaversineDistance(
+        lat1: Double,
+        lon1: Double,
+        lat2: Double,
+        lon2: Double
+    ): Int {
+        val earthRadiusMeters = 6371000.0 // 지구 반지름 (미터)
+
+        val dLat = Math.toRadians(lat2 - lat1)
+        val dLon = Math.toRadians(lon2 - lon1)
+
+        val a = sin(dLat / 2) * sin(dLat / 2) +
+                cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+                sin(dLon / 2) * sin(dLon / 2)
+
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+
+        return (earthRadiusMeters * c).toInt()
     }
 
     override fun onCleared() {

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MapViewModel.kt
@@ -19,22 +19,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlin.math.atan2
-import kotlin.math.cos
-import kotlin.math.sin
-import kotlin.math.sqrt
-
-/**
- * 참가자의 거리 정보
- * @param participant 참가자 정보
- * @param distanceInMeters 약속장소까지의 거리 (미터)
- * @param normalizedPosition 트래킹바 위치 (0.0f = 약속장소, 1.0f = 가장 먼 사람)
- */
-data class ParticipantDistance(
-    val participant: Participant,
-    val distanceInMeters: Int,
-    val normalizedPosition: Float
-)
 
 @HiltViewModel(assistedFactory = MapViewModel.Factory::class)
 class MapViewModel @AssistedInject constructor(
@@ -85,26 +69,6 @@ class MapViewModel @AssistedInject constructor(
     // 초기 위치 로딩 상태
     private val _isInitialLocationLoaded = MutableStateFlow(false)
     val isInitialLocationLoaded: StateFlow<Boolean> = _isInitialLocationLoaded.asStateFlow()
-
-    // 참가자 거리 정보 (트래킹바용)
-    private val _participantDistances = MutableStateFlow<List<ParticipantDistance>>(emptyList())
-    val participantDistances: StateFlow<List<ParticipantDistance>> = _participantDistances.asStateFlow()
-
-    init {
-        // 방 정보와 참가자 정보가 변경될 때마다 거리 계산
-        viewModelScope.launch {
-            kotlinx.coroutines.flow.combine(room, participants) { r, p ->
-                Pair(r, p)
-            }.collect { (currentRoom, currentParticipants) ->
-                currentRoom?.destination?.let { destination ->
-                    _participantDistances.value = calculateParticipantDistances(
-                        participants = currentParticipants,
-                        destination = destination
-                    )
-                }
-            }
-        }
-    }
 
     // 위치 추적 시작 (외부에서 호출 가능하도록 public으로 변경)
     fun startLocationTracking() {
@@ -161,79 +125,6 @@ class MapViewModel @AssistedInject constructor(
     // 에러 메시지 초기화
     fun clearError() {
         _error.value = null
-    }
-
-    /**
-     * 참가자들의 약속장소까지 거리 계산
-     * TODO: 나중에 route 정보가 있으면 경로 기반 거리로 변경
-     */
-    private fun calculateParticipantDistances(
-        participants: List<Participant>,
-        destination: com.teammanduk.adego.core.model.Place
-    ): List<ParticipantDistance> {
-        // 위치 정보가 있는 참가자만 필터링
-        val participantsWithLocation = participants.filter { it.location != null }
-
-        if (participantsWithLocation.isEmpty()) {
-            return emptyList()
-        }
-
-        // 각 참가자의 거리 계산
-        val distances = participantsWithLocation.map { participant ->
-            val location = participant.location!!
-
-            // TODO: route 정보가 있으면 route.distanceInMeters 사용
-            // 현재는 직선 거리 계산 (Haversine)
-            val distanceInMeters = calculateHaversineDistance(
-                lat1 = location.latitude,
-                lon1 = location.longitude,
-                lat2 = destination.latitude,
-                lon2 = destination.longitude
-            )
-
-            ParticipantDistance(
-                participant = participant,
-                distanceInMeters = distanceInMeters,
-                normalizedPosition = 0f // 아래에서 계산
-            )
-        }
-
-        // 가장 먼 거리 찾기
-        val maxDistance = distances.maxOfOrNull { it.distanceInMeters } ?: 1
-
-        // normalized position 계산 (0.0f ~ 1.0f)
-        return distances.map { distance ->
-            distance.copy(
-                normalizedPosition = if (maxDistance > 0) {
-                    distance.distanceInMeters.toFloat() / maxDistance.toFloat()
-                } else {
-                    0f
-                }
-            )
-        }
-    }
-
-    /**
-     * Haversine 공식을 사용한 두 지점 간 직선 거리 계산 (미터)
-     */
-    private fun calculateHaversineDistance(
-        lat1: Double,
-        lon1: Double,
-        lat2: Double,
-        lon2: Double
-    ): Int {
-        val earthRadiusMeters = 6371000.0 // 지구 반지름 (미터)
-
-        val dLat = Math.toRadians(lat2 - lat1)
-        val dLon = Math.toRadians(lon2 - lon1)
-
-        val a = sin(dLat / 2) * sin(dLat / 2) +
-                cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
-                sin(dLon / 2) * sin(dLon / 2)
-
-        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
-
-        return (earthRadiusMeters * c).toInt()
     }
 
     override fun onCleared() {

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MarkerIconFactory.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/MarkerIconFactory.kt
@@ -1,0 +1,94 @@
+package com.teammanduk.adego.feature.map
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.dp
+import com.google.android.gms.maps.model.BitmapDescriptor
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+
+/**
+ * 참가자 마커 아이콘을 생성하는 팩토리 함수
+ * Material Icons Person의 정확한 path를 사용하여 트래커/카드와 동일한 아이콘 생성
+ *
+ * @param color 참가자 색상
+ * @param isSelected 선택 여부 (선택 시 크기가 커짐)
+ * @return Google Maps Marker에 사용할 BitmapDescriptor
+ */
+@Composable
+fun createParticipantMarkerIcon(
+    color: Color,
+    isSelected: Boolean = false
+): BitmapDescriptor {
+    val density = androidx.compose.ui.platform.LocalDensity.current
+
+    val sizeDp = if (isSelected) 56 else 48 // 크기
+    val sizePx = with(density) { sizeDp.dp.roundToPx() }
+
+    val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+
+    val paint = android.graphics.Paint().apply {
+        isAntiAlias = true
+        style = android.graphics.Paint.Style.FILL
+    }
+
+    val centerX = sizePx / 2f
+    val centerY = sizePx / 2f
+    val outerRadius = sizePx / 2f - 6f // 여백
+    val innerRadius = outerRadius - 6f // 테두리 두께
+
+    // 흰색 테두리
+    paint.color = android.graphics.Color.WHITE
+    canvas.drawCircle(centerX, centerY, outerRadius, paint)
+
+    // 참가자 색상 원
+    paint.color = color.toArgb()
+    canvas.drawCircle(centerX, centerY, innerRadius, paint)
+
+    // Person 아이콘 (Material Icons의 정확한 path)
+    paint.color = android.graphics.Color.WHITE
+
+    // 아이콘 크기 계산 (트래커 바와 동일하게)
+    val iconSize = innerRadius * 1.2f
+    val scale = iconSize / 24f // Material Icons는 24x24 viewBox
+    val iconOffsetX = centerX - (iconSize / 2f)
+    val iconOffsetY = centerY - (iconSize / 2f)
+
+    // Material Icons Person path: M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z
+
+    // 머리 (원): center(12,8), radius 4
+    canvas.drawCircle(
+        12f * scale + iconOffsetX,
+        8f * scale + iconOffsetY,
+        4f * scale,
+        paint
+    )
+
+    // 몸통: 하단 사각형 영역
+    val bodyPath = android.graphics.Path().apply {
+        // 사각형 윤곽
+        moveTo(4f * scale + iconOffsetX, 18f * scale + iconOffsetY)
+        lineTo(4f * scale + iconOffsetX, 20f * scale + iconOffsetY)
+        lineTo(20f * scale + iconOffsetX, 20f * scale + iconOffsetY)
+        lineTo(20f * scale + iconOffsetX, 18f * scale + iconOffsetY)
+
+        // 상단 곡선 (c-2.67 0-8 1.34-8 4)
+        cubicTo(
+            20f * scale + iconOffsetX, 15.34f * scale + iconOffsetY,
+            14.67f * scale + iconOffsetX, 14f * scale + iconOffsetY,
+            12f * scale + iconOffsetX, 14f * scale + iconOffsetY
+        )
+        cubicTo(
+            9.33f * scale + iconOffsetX, 14f * scale + iconOffsetY,
+            4f * scale + iconOffsetX, 15.34f * scale + iconOffsetY,
+            4f * scale + iconOffsetX, 18f * scale + iconOffsetY
+        )
+        close()
+    }
+    canvas.drawPath(bodyPath, paint)
+
+    return BitmapDescriptorFactory.fromBitmap(bitmap)
+}

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/navigation/MapNavigation.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/navigation/MapNavigation.kt
@@ -1,5 +1,6 @@
 package com.teammanduk.adego.feature.map.navigation
 
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -7,13 +8,16 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.teammanduk.adego.core.navigation.Route
 import com.teammanduk.adego.feature.map.MapRoute
+import com.teammanduk.adego.feature.map.MapViewModel
 
 fun NavController.navigateToMap(
+    roomId: String,
+    userId: String,
     hour: Int,
     minute: Int,
     navOptions: NavOptions? = null
 ) {
-    navigate(Route.Map(hour = hour, minute = minute), navOptions)
+    navigate(Route.Map(roomId = roomId, userId = userId, hour = hour, minute = minute), navOptions)
 }
 
 fun NavGraphBuilder.mapNavGraph() {
@@ -21,8 +25,14 @@ fun NavGraphBuilder.mapNavGraph() {
         val route = backStackEntry.toRoute<Route.Map>()
         val meetingTime = String.format("%02d시 %02d분", route.hour, route.minute)
 
+        val viewModel: MapViewModel = hiltViewModel<MapViewModel, MapViewModel.Factory> { factory ->
+            factory.create(roomId = route.roomId, userId = route.userId)
+        }
+
         MapRoute(
-            meetingTime = meetingTime
+            roomId = route.roomId,
+            meetingTime = meetingTime,
+            viewModel = viewModel
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,16 @@ playServicesPlaces = "4.1.0"
 # https://ktor.io/
 ktor = "3.0.3"
 
+## Firebase
+# https://firebase.google.com/support/release-notes/android
+firebaseBom = "34.4.0"
+firebaseDatabaseKtx = "21.0.0"
+firebaseAuthKtx = "23.1.0"
+
+## Google Play Services
+# https://developers.google.com/android/guides/releases
+playServicesLocation = "21.3.0"
+
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -101,6 +111,14 @@ google-maps-compose = { group = "com.google.maps.android", name = "maps-compose"
 play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
 play-services-places = { group = "com.google.android.libraries.places", name = "places", version.ref = "playServicesPlaces" }
 
+## Google Play Services
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+
+## Firebase
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-database-ktx = { group = "com.google.firebase", name = "firebase-database-ktx", version.ref = "firebaseDatabaseKtx" }
+firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
+
 ## Network
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
@@ -126,6 +144,7 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlinJvm" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+google-services = { id = "com.google.gms.google-services", version = "4.4.2" }
 
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
  ## 개요
  지도 화면에 MVI (Model-View-Intent) 아키텍처 패턴을 적용하여 상태 관리를 개선했습니다.

  ## 주요 변경사항

  ### 1. MapIntent.kt 추가
  - sealed interface로 사용자 액션 정의
  - SelectParticipant, ClearError, ShowInviteDialog, DismissInviteDialog

  ### 2. MapViewModel 리팩토링
  - MapUiState 데이터 클래스로 UI 상태 통합
  - onAction() 함수: 단일 진입점으로 모든 Intent 처리
  - reduce() 함수: 순수 함수로 상태 변환 처리
  - 기존 함수들을 @Deprecated로 마킹하여 하위 호환성 유지

  ### 3. MapScreen 업데이트
  - Intent 기반 상태 관리로 전환
  - pagerState와 ViewModel 양방향 동기화 구현
  - 로컬 상태 제거하고 ViewModel로 통합

  ### 4. MarkerIconFactory 분리
  - 참가자 마커 아이콘 생성 로직을 별도 파일로 분리
  - Material Icons Person path 사용하여 일관된 아이콘 생성

  ## 기술 스택
  - MVI Architecture Pattern
  - Kotlin Coroutines Flow
  - Jetpack Compose State Management

  ## 변경 파일
  - 4 files changed, 628 insertions(+), 282 deletions(-)
  - MapIntent.kt (신규)
  - MarkerIconFactory.kt (신규)
  - MapViewModel.kt (수정)
  - MapScreen.kt (수정)

  ## 테스트
  - [x] 빌드 성공
  - [x] 참가자 선택 동작 확인
  - [x] 초대 다이얼로그 상태 관리 확인
