### PR TITLE
  feat: a-dego.web.app 딥링크 설정 및 자동 앱 실행 구현

### DIFF
--- a/feature/main/src/main/AndroidManifest.xml
+++ b/feature/main/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <!-- Deep Link for invite - Custom Scheme -->
+            <!-- Custom Scheme Deep Link -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -22,19 +22,19 @@
                     android:host="join" />
             </intent-filter>
 
-            <!-- Deep Link for invite - HTTP/HTTPS -->
+            <!-- HTTPS App Links -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
-                    android:scheme="http"
-                    android:host="adego.kr"
-                    android:pathPrefix="/join" />
+                    android:host="a-dego.web.app"
+                    android:pathPrefix="/join"
+                    android:scheme="https" />
                 <data
-                    android:scheme="https"
                     android:host="adego.kr"
-                    android:pathPrefix="/join" />
+                    android:pathPrefix="/join"
+                    android:scheme="https" />
             </intent-filter>
 
         </activity>

--- a/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainActivity.kt
+++ b/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainActivity.kt
@@ -46,9 +46,9 @@ class MainActivity : ComponentActivity() {
             data.scheme == "adego" && data.host == "join" -> {
                 data.pathSegments.firstOrNull()
             }
-            // http(s)://adego.kr/join/{roomId} 형식 처리
+            // http(s)://a-dego.web.app/join/{roomId} 또는 adego.kr/join/{roomId} 형식 처리
             (data.scheme == "http" || data.scheme == "https") &&
-            data.host == "adego.kr" &&
+            (data.host == "a-dego.web.app" || data.host == "adego.kr") &&
             data.pathSegments.firstOrNull() == "join" -> {
                 data.pathSegments.getOrNull(1)
             }

--- a/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/component/InviteDialog.kt
+++ b/feature/map/src/main/kotlin/com/teammanduk/adego/feature/map/component/InviteDialog.kt
@@ -142,7 +142,7 @@ fun InviteDialog(
                 ) {
                     IconButton(
                         onClick = {
-                            val deepLink = "https://adego.kr/join/$inviteCode"
+                            val deepLink = "https://a-dego.web.app/join/$inviteCode"
                             val message = """
                                 |🗺️ A-dego 모임 초대
                                 |
@@ -150,7 +150,7 @@ fun InviteDialog(
                                 |목적지: $destinationName
                                 |시간: $meetingTime
                                 |
-                                |앱으로 바로 참가하기: $deepLink
+                                |참가하기: $deepLink
                             """.trimMargin()
 
                             val smsIntent = Intent(Intent.ACTION_SENDTO).apply {
@@ -186,7 +186,7 @@ fun InviteDialog(
                 ) {
                     IconButton(
                         onClick = {
-                            val deepLink = "https://adego.kr/join/$inviteCode"
+                            val deepLink = "https://a-dego.web.app/join/$inviteCode"
                             val message = """
                                 |🗺️ A-dego 모임 초대
                                 |
@@ -194,7 +194,7 @@ fun InviteDialog(
                                 |목적지: $destinationName
                                 |시간: $meetingTime
                                 |
-                                |앱으로 바로 참가하기: $deepLink
+                                |참가하기: $deepLink
                             """.trimMargin()
 
                             val shareIntent = Intent(Intent.ACTION_SEND).apply {


### PR DESCRIPTION
 ## Summary
  - a-dego.web.app 도메인으로 딥링크 설정 완료
  - 메신저에서 초대 링크 클릭 시 자동으로 앱 실행
  - Firebase Hosting 배포 완료

  ## 주요 변경사항
  - AndroidManifest에 Custom Scheme(`adego://`) intent-filter 추가
  - a-dego.web.app 도메인 App Links 설정 (adego.kr도 호환)
  - MainActivity 딥링크 핸들러에서 양쪽 도메인 모두 지원
  - InviteDialog 공유 메시지를 a-dego.web.app으로 변경
  - index.html에 Intent URL 리다이렉션 로직 추가
  - assetlinks.json에 SHA-256 지문 추가 및 Firebase Hosting 배포

  ## Test Plan
  - [x] 메신저에서 `https://a-dego.web.app/join/{roomId}` 링크 클릭 테스트
  - [x] Intent URL로 자동 앱 실행 확인
  - [x] 앱이 없는 경우 Play Store 안내 확인
  - [x] Firebase Hosting 배포 및 assetlinks.json 정상 서빙 확인

  ## TODO
  - [ ] adego.kr 도메인 인증서 발급 후 a-dego.web.app → adego.kr로 변경