### PR TITLE
  feat: 세션 유지 기능 구현

### DIFF
--- a/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/datasource/SessionDataSource.kt
+++ b/core/data-api/src/main/kotlin/com/teammanduk/adego/core/data_api/datasource/SessionDataSource.kt
@@ -1,0 +1,54 @@
+package com.teammanduk.adego.core.data_api.datasource
+
+/**
+ * 세션 로컬 저장소
+ *
+ * 사용자 ID, 방 정보, 사용자 이름을 로컬에 저장하여
+ * 앱 재시작 시에도 세션을 유지할 수 있도록 함
+ */
+interface SessionDataSource {
+    /**
+     * 현재 사용자 ID 저장
+     */
+    suspend fun saveUserId(userId: String)
+
+    /**
+     * 현재 사용자 ID 조회
+     */
+    suspend fun getUserId(): String?
+
+    /**
+     * 현재 사용자 이름 저장
+     */
+    suspend fun saveUserName(userName: String)
+
+    /**
+     * 현재 사용자 이름 조회
+     */
+    suspend fun getUserName(): String?
+
+    /**
+     * 현재 방 ID 저장
+     */
+    suspend fun saveRoomId(roomId: String)
+
+    /**
+     * 현재 방 ID 조회
+     */
+    suspend fun getRoomId(): String?
+
+    /**
+     * 현재 방 이름 저장
+     */
+    suspend fun saveRoomName(roomName: String)
+
+    /**
+     * 현재 방 이름 조회
+     */
+    suspend fun getRoomName(): String?
+
+    /**
+     * 모든 세션 정보 삭제
+     */
+    suspend fun clearSession()
+}

--- a/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/RoomRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/RoomRepositoryImpl.kt
@@ -47,6 +47,15 @@ class RoomRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun restoreRoomSession(): String? {
+        val roomId = sessionDataSource.getRoomId()
+        if (roomId != null) {
+            currentRoomId = roomId
+            Log.d(TAG, "[Repository] 방 세션 복구: $roomId")
+        }
+        return roomId
+    }
+
     // ===== 현재 방 기준 작업 (세션 기반) =====
     override fun observeCurrentRoom(): Flow<Room?> {
         val roomId = currentRoomId

--- a/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/RoomRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/RoomRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.teammanduk.adego.core.data.mapper.toDto
 import com.teammanduk.adego.core.data.mapper.toModel
 import com.teammanduk.adego.core.data_api.datasource.RoomDataSource
+import com.teammanduk.adego.core.data_api.datasource.SessionDataSource
 import com.teammanduk.adego.core.data_api.model.ParticipantDto
 import com.teammanduk.adego.core.domain.repository.RoomRepository
 import com.teammanduk.adego.core.model.Participant
@@ -13,12 +14,14 @@ import com.teammanduk.adego.core.model.Place
 import com.teammanduk.adego.core.model.Room
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class RoomRepositoryImpl @Inject constructor(
-    private val roomDataSource: RoomDataSource
+    private val roomDataSource: RoomDataSource,
+    private val sessionDataSource: SessionDataSource
 ) : RoomRepository {
 
     // 현재 참여 중인 방 ID (세션 정보)
@@ -27,6 +30,10 @@ class RoomRepositoryImpl @Inject constructor(
     // ===== 세션 관리 =====
     override fun setCurrentRoom(roomId: String) {
         currentRoomId = roomId
+        runBlocking {
+            sessionDataSource.saveRoomId(roomId)
+            // roomName은 joinRoom이나 createRoom에서 저장
+        }
         Log.d(TAG, "[Repository] 현재 방 세션 설정: $roomId")
     }
 
@@ -35,6 +42,9 @@ class RoomRepositoryImpl @Inject constructor(
     override fun clearCurrentRoom() {
         Log.d(TAG, "[Repository] 현재 방 세션 종료: $currentRoomId")
         currentRoomId = null
+        runBlocking {
+            sessionDataSource.clearSession()
+        }
     }
 
     // ===== 현재 방 기준 작업 (세션 기반) =====
@@ -146,6 +156,10 @@ class RoomRepositoryImpl @Inject constructor(
             roomDataSource.addParticipant(roomId, creatorParticipant).getOrThrow()
             Log.d(TAG, "[Repository] 참여자 추가 완료")
 
+            // 세션에 사용자 정보 및 방 정보 저장
+            sessionDataSource.saveUserName(userName)
+            sessionDataSource.saveRoomName(roomName)
+
             Log.d(TAG, "[Repository] 방 생성 완료! roomId=$roomId")
             Result.success(roomId)
         } catch (e: Exception) {
@@ -183,7 +197,13 @@ class RoomRepositoryImpl @Inject constructor(
                 route = null
             )
 
-            roomDataSource.addParticipant(roomId, participant)
+            roomDataSource.addParticipant(roomId, participant).getOrThrow()
+
+            // 세션에 사용자 정보 및 방 정보 저장
+            sessionDataSource.saveUserName(userName)
+            sessionDataSource.saveRoomName(room.roomName)
+
+            Result.success(Unit)
         } catch (e: Exception) {
             Log.e(TAG, "[Repository] 방 참여 실패", e)
             Result.failure(e)

--- a/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/UserRepositoryImpl.kt
@@ -30,4 +30,12 @@ class UserRepositoryImpl @Inject constructor(
             sessionDataSource.clearSession()
         }
     }
+
+    override suspend fun restoreUserSession(): String? {
+        val userId = sessionDataSource.getUserId()
+        if (userId != null) {
+            currentUserId = userId
+        }
+        return userId
+    }
 }

--- a/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/teammanduk/adego/core/data/repository/UserRepositoryImpl.kt
@@ -1,16 +1,23 @@
 package com.teammanduk.adego.core.data.repository
 
+import com.teammanduk.adego.core.data_api.datasource.SessionDataSource
 import com.teammanduk.adego.core.domain.repository.UserRepository
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class UserRepositoryImpl @Inject constructor() : UserRepository {
+class UserRepositoryImpl @Inject constructor(
+    private val sessionDataSource: SessionDataSource
+) : UserRepository {
 
     private var currentUserId: String? = null
 
     override fun setCurrentUser(userId: String) {
         currentUserId = userId
+        runBlocking {
+            sessionDataSource.saveUserId(userId)
+        }
     }
 
     override fun getCurrentUserId(): String {
@@ -19,5 +26,8 @@ class UserRepositoryImpl @Inject constructor() : UserRepository {
 
     override fun clearCurrentUser() {
         currentUserId = null
+        runBlocking {
+            sessionDataSource.clearSession()
+        }
     }
 }

--- a/core/domain/src/main/kotlin/com/teammanduk/adego/core/domain/repository/RoomRepository.kt
+++ b/core/domain/src/main/kotlin/com/teammanduk/adego/core/domain/repository/RoomRepository.kt
@@ -23,6 +23,12 @@ interface RoomRepository {
      */
     fun clearCurrentRoom()
 
+    /**
+     * DataStore에서 저장된 방 정보 복구
+     * @return 저장된 roomId (없으면 null)
+     */
+    suspend fun restoreRoomSession(): String?
+
     // ===== 현재 방 기준 작업 (세션 기반) =====
     /**
      * 현재 방 정보 실시간 구독

--- a/core/domain/src/main/kotlin/com/teammanduk/adego/core/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/kotlin/com/teammanduk/adego/core/domain/repository/UserRepository.kt
@@ -4,4 +4,10 @@ interface UserRepository {
     fun setCurrentUser(userId: String)
     fun getCurrentUserId(): String
     fun clearCurrentUser()
+
+    /**
+     * DataStore에서 저장된 사용자 정보 복구
+     * @return 저장된 userId (없으면 null)
+     */
+    suspend fun restoreUserSession(): String?
 }

--- a/core/domain/src/main/kotlin/com/teammanduk/adego/core/domain/usecase/RestoreSessionUseCase.kt
+++ b/core/domain/src/main/kotlin/com/teammanduk/adego/core/domain/usecase/RestoreSessionUseCase.kt
@@ -1,0 +1,45 @@
+package com.teammanduk.adego.core.domain.usecase
+
+import com.teammanduk.adego.core.domain.repository.RoomRepository
+import com.teammanduk.adego.core.domain.repository.UserRepository
+import javax.inject.Inject
+
+/**
+ * 저장된 세션 정보 복구 UseCase
+ *
+ * DataStore에 저장된 세션 정보를 읽어서
+ * UserRepository와 RoomRepository의 상태를 복원
+ */
+class RestoreSessionUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+    private val roomRepository: RoomRepository
+) {
+    /**
+     * 세션 정보 복구
+     *
+     * @return SessionInfo? - 복구된 세션 정보 (없으면 null)
+     */
+    suspend operator fun invoke(): SessionInfo? {
+        // Repository에서 세션 정보 복구
+        val userId = userRepository.restoreUserSession()
+        val roomId = roomRepository.restoreRoomSession()
+
+        // 필수 정보가 모두 있는지 확인
+        return if (userId != null && roomId != null) {
+            SessionInfo(
+                userId = userId,
+                roomId = roomId
+            )
+        } else {
+            null
+        }
+    }
+}
+
+/**
+ * 세션 정보 데이터 클래스
+ */
+data class SessionInfo(
+    val userId: String,
+    val roomId: String
+)

--- a/core/local/build.gradle.kts
+++ b/core/local/build.gradle.kts
@@ -1,0 +1,16 @@
+import com.teammanduk.adego.extentions.setNamespace
+
+plugins {
+    alias(libs.plugins.adego.android.library)
+    alias(libs.plugins.adego.android.hilt)
+}
+
+setNamespace("core.local")
+
+dependencies {
+    implementation(projects.core.dataApi)
+    implementation(projects.core.model)
+
+    // DataStore
+    implementation(libs.androidx.datastore.preferences)
+}

--- a/core/local/src/main/kotlin/com/teammanduk/adego/core/local/datasource/SessionDataSourceImpl.kt
+++ b/core/local/src/main/kotlin/com/teammanduk/adego/core/local/datasource/SessionDataSourceImpl.kt
@@ -1,0 +1,78 @@
+package com.teammanduk.adego.core.local.datasource
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.teammanduk.adego.core.data_api.datasource.SessionDataSource
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SessionDataSourceImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : SessionDataSource {
+
+    private object PreferencesKeys {
+        val USER_ID = stringPreferencesKey("user_id")
+        val USER_NAME = stringPreferencesKey("user_name")
+        val ROOM_ID = stringPreferencesKey("room_id")
+        val ROOM_NAME = stringPreferencesKey("room_name")
+    }
+
+    override suspend fun saveUserId(userId: String) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.USER_ID] = userId
+        }
+    }
+
+    override suspend fun getUserId(): String? {
+        return dataStore.data.map { preferences ->
+            preferences[PreferencesKeys.USER_ID]
+        }.first()
+    }
+
+    override suspend fun saveUserName(userName: String) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.USER_NAME] = userName
+        }
+    }
+
+    override suspend fun getUserName(): String? {
+        return dataStore.data.map { preferences ->
+            preferences[PreferencesKeys.USER_NAME]
+        }.first()
+    }
+
+    override suspend fun saveRoomId(roomId: String) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.ROOM_ID] = roomId
+        }
+    }
+
+    override suspend fun getRoomId(): String? {
+        return dataStore.data.map { preferences ->
+            preferences[PreferencesKeys.ROOM_ID]
+        }.first()
+    }
+
+    override suspend fun saveRoomName(roomName: String) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.ROOM_NAME] = roomName
+        }
+    }
+
+    override suspend fun getRoomName(): String? {
+        return dataStore.data.map { preferences ->
+            preferences[PreferencesKeys.ROOM_NAME]
+        }.first()
+    }
+
+    override suspend fun clearSession() {
+        dataStore.edit { preferences ->
+            preferences.clear()
+        }
+    }
+}

--- a/core/local/src/main/kotlin/com/teammanduk/adego/core/local/di/LocalModule.kt
+++ b/core/local/src/main/kotlin/com/teammanduk/adego/core/local/di/LocalModule.kt
@@ -1,0 +1,41 @@
+package com.teammanduk.adego.core.local.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.teammanduk.adego.core.data_api.datasource.SessionDataSource
+import com.teammanduk.adego.core.local.datasource.SessionDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "user_session")
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LocalModule {
+
+    @Provides
+    @Singleton
+    fun provideDataStore(
+        @ApplicationContext context: Context
+    ): DataStore<Preferences> {
+        return context.dataStore
+    }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface LocalBindModule {
+
+    @Binds
+    @Singleton
+    fun bindSessionDataSource(
+        impl: SessionDataSourceImpl
+    ): SessionDataSource
+}

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -13,5 +13,6 @@ dependencies {
     implementation(projects.feature.place)
     implementation(projects.feature.route)
     implementation(projects.core.data)
+    implementation(projects.core.local)
     implementation(projects.core.remote)
 }

--- a/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainActivity.kt
+++ b/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainActivity.kt
@@ -5,7 +5,10 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import com.teammanduk.adego.core.designsystem.ui.theme.AdegoTheme
 import com.teammanduk.adego.feature.main.navigation.rememberMainNavigator
 import dagger.hilt.android.AndroidEntryPoint
@@ -13,12 +16,29 @@ import java.util.UUID
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private val viewModel: MainViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
         setContent {
             val navigator = rememberMainNavigator()
+            val sessionState by viewModel.sessionState.collectAsState()
+
+            // 세션 복구 처리
+            LaunchedEffect(sessionState) {
+                when (val state = sessionState) {
+                    is SessionState.Restored -> {
+                        // 세션이 있으면 Map 화면으로 자동 이동
+                        navigator.navigateToMap(state.sessionInfo.roomId, state.sessionInfo.userId)
+                    }
+                    SessionState.None, SessionState.Loading -> {
+                        // 세션이 없거나 로딩 중이면 아무것도 안 함 (Home 화면에 머무름)
+                    }
+                }
+            }
 
             // 딥링크 처리
             LaunchedEffect(intent) {

--- a/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainViewModel.kt
+++ b/feature/main/src/main/kotlin/com/teammanduk/adego/feature/main/MainViewModel.kt
@@ -1,0 +1,42 @@
+package com.teammanduk.adego.feature.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.teammanduk.adego.core.domain.usecase.RestoreSessionUseCase
+import com.teammanduk.adego.core.domain.usecase.SessionInfo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val restoreSession: RestoreSessionUseCase
+) : ViewModel() {
+
+    private val _sessionState = MutableStateFlow<SessionState>(SessionState.Loading)
+    val sessionState: StateFlow<SessionState> = _sessionState.asStateFlow()
+
+    init {
+        checkSession()
+    }
+
+    private fun checkSession() {
+        viewModelScope.launch {
+            val sessionInfo = restoreSession()
+            _sessionState.value = if (sessionInfo != null) {
+                SessionState.Restored(sessionInfo)
+            } else {
+                SessionState.None
+            }
+        }
+    }
+}
+
+sealed interface SessionState {
+    data object Loading : SessionState
+    data object None : SessionState
+    data class Restored(val sessionInfo: SessionInfo) : SessionState
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,10 @@ material = "1.13.0"
 activity = "1.10.1"
 constraintlayout = "2.1.4"
 
+## DataStore
+# https://developer.android.com/jetpack/androidx/releases/datastore
+androidxDataStore = "1.1.1"
+
 [libraries]
 ## Gradle Plugin
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
@@ -140,6 +144,9 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+
+## DataStore
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDataStore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include(
     ":core:ui",
     ":core:navigation",
     ":core:data-api",
+    ":core:local",
     ":core:remote",
     ":core:data",
     ":core:domain",


### PR DESCRIPTION
  ## Summary
  - DataStore 기반 세션 저장 및 복구 기능 구현
  - 앱 재시작 시 자동으로 이전 방으로 복귀
  - 위치 업데이트 로직을 Repository로 이동하여 레이어 분리 개선
  - 클린 아키텍처 개선 (Domain Layer가 DataSource 직접 참조하지 않도록 수정)

  ## 주요 변경사항
  ### 1. DataStore 기반 세션 저장
  - SessionDataSource 추가 (userId, roomId 저장)
  - createRoom, joinRoom 시 세션 자동 저장
  - clearSession으로 세션 정리

  ### 2. 세션 복구 기능
  - RoomRepository, UserRepository에 세션 복구 메서드 추가
  - RestoreSessionUseCase 구현 (Repository만 참조하도록 개선)
  - MainViewModel에서 앱 시작 시 세션 복구 처리
  - 세션이 있으면 Map 화면으로 자동 이동

  ### 3. 레이어 분리 개선
  - 위치 방송 로직을 MapViewModel → BroadcastLocationUseCase로 이동
  - 위치 업데이트 상태 관리를 LocationRepository로 이동
  - LeaveRoomSessionUseCase 추가 (방 나가기 + 위치 업데이트 중단)

  ## TODO
  - [ ] 세션 복구 시 닉네임 입력 다이얼로그 스킵 처리
  - [ ] Map 화면에서 백버튼으로 Home 이동 방지

  ## Test plan
  - [ ] 방 생성 후 앱 종료, 재시작 시 해당 방으로 자동 복귀 확인
  - [ ] 방 참여 후 앱 종료, 재시작 시 해당 방으로 자동 복귀 확인
  - [ ] 방 나가기 후 앱 재시작 시 Home 화면 유지 확인
  - [ ] 딥링크로 새 방 참여 시 세션 정상 저장 확인

  다음 작업 TODO

  1. 세션 복구 시 닉네임 입력 다이얼로그 스킵 처리
  2. Map 화면에서 백버튼으로 Home 이동 방지